### PR TITLE
Add crossfade playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Yuzic provides a Navidrome demo but requires a self-hosted Jellyfin or Subsonic 
 - Search & Browsing
 - Privacy-First by Design
 - Fast, Reliable Playback
+- Crossfading
 - External Downloaders
 - Deezer
 - Lastfm
@@ -47,7 +48,6 @@ Yuzic provides a Navidrome demo but requires a self-hosted Jellyfin or Subsonic 
 - Casting
 
 ## Future
-- Crossfading
 - Apple TV app
 - Apple watch
 - F-droid

--- a/app.json
+++ b/app.json
@@ -71,7 +71,8 @@
           "iosReceiverAppID": "BCF2CA91",
           "androidReceiverAppID": "BCF2CA91"
         }
-      ]
+      ],
+      "expo-audio"
     ],
     "experiments": {
       "typedRoutes": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@tanstack/react-query": "^5.90.16",
         "@tanstack/react-query-persist-client": "^5.90.19",
         "expo": "^55.0.23",
+        "expo-audio": "~55.0.15",
         "expo-blur": "~55.0.14",
         "expo-build-properties": "~55.0.13",
         "expo-constants": "~55.0.14",
@@ -8696,6 +8697,18 @@
       },
       "peerDependencies": {
         "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-audio": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-55.0.15.tgz",
+      "integrity": "sha512-VS5112dO7sUivJpqLjAJLsP4Cv1c4o92wrMqkUCPA/879f8hy6RUQI7t2NVTnK5qkVzp1MtzkWhArwAtjVuVHg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "expo-asset": "*",
         "react": "*",
         "react-native": "*"
       }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-query-persist-client": "^5.90.19",
     "expo": "^55.0.23",
+    "expo-audio": "~55.0.15",
     "expo-blur": "~55.0.14",
     "expo-build-properties": "~55.0.13",
     "expo-constants": "~55.0.14",

--- a/src/contexts/PlayingContext.tsx
+++ b/src/contexts/PlayingContext.tsx
@@ -18,6 +18,12 @@ import TrackPlayer, {
   useIsPlaying,
   useProgress,
 } from '@rntp/player';
+import {
+  createAudioPlayer,
+  setAudioModeAsync,
+  type AudioPlayer,
+  type AudioSource,
+} from 'expo-audio';
 
 import { Album, Playlist, Song } from '@/types';
 import shuffleArray from '@/utils/shuffleArray';
@@ -31,7 +37,13 @@ import { useCast } from './CastContext';
 import { useScrobbling } from '@/hooks/useScrobbling';
 import { useCarPlayBrowseTree } from '@/hooks/useCarPlayBrowseTree';
 import { useSelector } from 'react-redux';
-import { selectWifiStreamQuality, selectCellularStreamQuality, selectPreferredCodec } from '@/utils/redux/selectors/settingsSelectors';
+import {
+  selectCellularStreamQuality,
+  selectCrossfadeDurationSeconds,
+  selectCrossfadeEnabled,
+  selectPreferredCodec,
+  selectWifiStreamQuality,
+} from '@/utils/redux/selectors/settingsSelectors';
 import { useNetworkType } from '@/hooks/useNetworkType';
 
 export interface PlaybackProgress {
@@ -89,6 +101,13 @@ const PlayingActionsContext = createContext<PlayingActionsType | undefined>(unde
 const PlayingProgressContext = createContext<PlaybackProgress>({ position: 0, duration: 0, buffered: 0 });
 
 let playerWasSetup = false;
+
+const PLAYER_VOLUME_FULL = 1;
+const PLAYER_VOLUME_MUTED = 0;
+const CROSSFADE_POLL_INTERVAL_MS = 250;
+const CROSSFADE_VOLUME_STEP_MS = 100;
+const CROSSFADE_SEEK_TOLERANCE_MS = 75;
+const CROSSFADE_MIN_OVERLAP_SECONDS = 1;
 
 export const usePlayingState = () => {
   const ctx = useContext(PlayingStateContext);
@@ -162,6 +181,21 @@ function hasSameQueueIds(current: Song[], next: Song[]): boolean {
 
 const toMediaItems = (songs: Song[]): MediaItem[] => songs.map(buildTrackItem);
 
+function mediaUrlToAudioSource(url: MediaItem['url']): AudioSource | null {
+  if (typeof url === 'number' || typeof url === 'string') return url;
+  if (typeof url === 'object' && url?.uri) {
+    return {
+      uri: url.uri,
+      headers: url.headers,
+    };
+  }
+  return null;
+}
+
+function songToCrossfadeAudioSource(song: Song): AudioSource | null {
+  return mediaUrlToAudioSource(buildTrackItem(song).url);
+}
+
 function getSourceKind(song: Song | null): string {
   if (!song?.streamUrl) return 'none';
   if (song.filePath || song.streamUrl.startsWith('file:')) return 'file';
@@ -197,7 +231,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   const activeMediaItem = useActiveMediaItem();
   const api = useApi();
   const { getLocalPath } = useDownloadActions();
-  const { activeDevice, castPause, castResume } = useCast();
+  const { activeDevice, isGoogleCastConnected, castPause, castResume } = useCast();
   const networkType = useNetworkType();
   const wifiQuality = useSelector(selectWifiStreamQuality);
   const cellularQuality = useSelector(selectCellularStreamQuality);
@@ -209,6 +243,12 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   const preferredCodec = useSelector(selectPreferredCodec);
   const preferredCodecRef = useRef(preferredCodec);
   preferredCodecRef.current = preferredCodec;
+  const crossfadeEnabled = useSelector(selectCrossfadeEnabled);
+  const crossfadeDurationSeconds = useSelector(selectCrossfadeDurationSeconds);
+  const crossfadeEnabledRef = useRef(crossfadeEnabled);
+  crossfadeEnabledRef.current = crossfadeEnabled;
+  const crossfadeDurationSecondsRef = useRef(crossfadeDurationSeconds);
+  crossfadeDurationSecondsRef.current = crossfadeDurationSeconds;
 
   const [currentSong, setCurrentSong] = useState<Song | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -226,8 +266,13 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   const repeatModeRef = useRef<RepeatModeState>('off');
   const shuffleOnRef = useRef(false);
   const isPlayingRef = useRef(false);
+  const localPlaybackMutedForCastRef = useRef(false);
   const isShufflingRef = useRef(false);
   const lastPlaybackErrorAtRef = useRef(0);
+  const crossfadeInProgressRef = useRef(false);
+  const crossfadeRunIdRef = useRef(0);
+  const crossfadeTailPlayerRef = useRef<AudioPlayer | null>(null);
+  const fadeTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   // Stable refs to latest callbacks — avoids stale closures in effects without listing
   // volatile deps, while keeping the callbacks themselves stable for context consumers.
@@ -246,8 +291,19 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   useEffect(() => { repeatModeRef.current = repeatMode; }, [repeatMode]);
   useEffect(() => { shuffleOnRef.current = shuffleOn; }, [shuffleOn]);
   useEffect(() => { isPlayingRef.current = isPlaying; }, [isPlaying]);
+  useEffect(() => {
+    localPlaybackMutedForCastRef.current = Boolean(activeDevice || isGoogleCastConnected);
+  }, [activeDevice, isGoogleCastConnected]);
 
   useCarPlayBrowseTree();
+
+  useEffect(() => {
+    setAudioModeAsync({
+      playsInSilentMode: true,
+      interruptionMode: 'mixWithOthers',
+      shouldPlayInBackground: true,
+    }).catch(err => console.warn('Crossfade audio mode setup failed', err));
+  }, []);
 
   useEffect(() => {
     if (!playerWasSetup) {
@@ -290,7 +346,170 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
 
   const bumpQueue = useCallback(() => setQueueVersion(v => v + 1), []);
 
+  const clearFadeTimeouts = useCallback(() => {
+    fadeTimeoutsRef.current.forEach(clearTimeout);
+    fadeTimeoutsRef.current = [];
+  }, []);
+
+  const releaseCrossfadeTailPlayer = useCallback(() => {
+    const player = crossfadeTailPlayerRef.current;
+    if (!player) return;
+    crossfadeTailPlayerRef.current = null;
+    try {
+      player.pause();
+      player.remove();
+    } catch (err) {
+      console.warn('Crossfade tail player cleanup failed', err);
+    }
+  }, []);
+
+  const restoreTrackPlayerVolume = useCallback(() => {
+    if (!localPlaybackMutedForCastRef.current) {
+      TrackPlayer.setVolume(PLAYER_VOLUME_FULL);
+    }
+  }, []);
+
+  const cancelCrossfade = useCallback(() => {
+    crossfadeRunIdRef.current += 1;
+    clearFadeTimeouts();
+    releaseCrossfadeTailPlayer();
+    crossfadeInProgressRef.current = false;
+    restoreTrackPlayerVolume();
+  }, [clearFadeTimeouts, releaseCrossfadeTailPlayer, restoreTrackPlayerVolume]);
+
+  const scheduleCrossfadeVolumes = useCallback((
+    durationMs: number,
+    onProgress: (progress: number) => void,
+    onComplete?: () => void
+  ) => {
+    const steps = Math.max(1, Math.ceil(durationMs / CROSSFADE_VOLUME_STEP_MS));
+    const stepMs = Math.max(1, durationMs / steps);
+
+    Array.from({ length: steps }, (_, index) => {
+      const timeout = setTimeout(() => {
+        const progress = (index + 1) / steps;
+        onProgress(progress);
+        if (index === steps - 1) onComplete?.();
+      }, stepMs * (index + 1));
+      fadeTimeoutsRef.current.push(timeout);
+    });
+  }, []);
+
+  const hasNextCrossfadeTarget = useCallback(() => {
+    if (queueRef.current.length < 2) return false;
+    const nextIndex = currentIndexRef.current + 1;
+    return nextIndex < queueRef.current.length || repeatModeRef.current === 'all';
+  }, []);
+
+  const startCrossfadeToNext = useCallback(async () => {
+    if (crossfadeInProgressRef.current || !hasNextCrossfadeTarget()) return;
+
+    const currentSongForTail = currentSongRef.current;
+    const currentSource = currentSongForTail ? songToCrossfadeAudioSource(currentSongForTail) : null;
+    const nextIndex = currentIndexRef.current + 1;
+    const targetIndex = nextIndex >= queueRef.current.length && repeatModeRef.current === 'all'
+      ? 0
+      : nextIndex;
+    const targetSong = queueRef.current[targetIndex];
+    if (!currentSongForTail || !currentSource || !targetSong) return;
+
+    crossfadeInProgressRef.current = true;
+    const runId = crossfadeRunIdRef.current + 1;
+    crossfadeRunIdRef.current = runId;
+    clearFadeTimeouts();
+    releaseCrossfadeTailPlayer();
+
+    try {
+      const initialProgress = TrackPlayer.getProgress();
+      if (!Number.isFinite(initialProgress.position) || !Number.isFinite(initialProgress.duration)) {
+        crossfadeInProgressRef.current = false;
+        return;
+      }
+
+      const tailPlayer = createAudioPlayer(currentSource, {
+        updateInterval: CROSSFADE_VOLUME_STEP_MS,
+        keepAudioSessionActive: true,
+        preferredForwardBufferDuration: crossfadeDurationSecondsRef.current,
+      });
+      crossfadeTailPlayerRef.current = tailPlayer;
+      tailPlayer.volume = PLAYER_VOLUME_FULL;
+
+      const handoffProgress = TrackPlayer.getProgress();
+      if (!Number.isFinite(handoffProgress.position) || !Number.isFinite(handoffProgress.duration)) {
+        releaseCrossfadeTailPlayer();
+        crossfadeInProgressRef.current = false;
+        return;
+      }
+
+      const remainingSeconds = Math.max(0, handoffProgress.duration - handoffProgress.position);
+      const overlapSeconds = Math.min(crossfadeDurationSecondsRef.current, remainingSeconds);
+      if (overlapSeconds < CROSSFADE_MIN_OVERLAP_SECONDS) {
+        releaseCrossfadeTailPlayer();
+        crossfadeInProgressRef.current = false;
+        return;
+      }
+
+      await tailPlayer.seekTo(
+        handoffProgress.position,
+        CROSSFADE_SEEK_TOLERANCE_MS,
+        CROSSFADE_SEEK_TOLERANCE_MS
+      );
+
+      if (crossfadeRunIdRef.current !== runId) {
+        releaseCrossfadeTailPlayer();
+        return;
+      }
+
+      void scrobbleIfNeededRef.current(currentSongForTail, {
+        listenedSeconds: Math.floor(Math.min(handoffProgress.duration, handoffProgress.position + overlapSeconds)),
+        startTime: scrobbleStartTimeRef.current,
+      }).catch(err => console.warn('Crossfade scrobble failed', err));
+      scrobbleStartTimeRef.current = Date.now();
+
+      if (crossfadeRunIdRef.current !== runId) {
+        releaseCrossfadeTailPlayer();
+        return;
+      }
+
+      tailPlayer.play();
+      TrackPlayer.setVolume(PLAYER_VOLUME_MUTED);
+      TrackPlayer.skipToIndex(targetIndex);
+      if (isPlayingRef.current) TrackPlayer.play();
+
+      scheduleCrossfadeVolumes(
+        overlapSeconds * 1000,
+        progress => {
+          if (crossfadeRunIdRef.current !== runId) return;
+          TrackPlayer.setVolume(progress);
+          if (crossfadeTailPlayerRef.current === tailPlayer) {
+            tailPlayer.volume = PLAYER_VOLUME_FULL - progress;
+          }
+        },
+        () => {
+          if (crossfadeRunIdRef.current !== runId) return;
+          releaseCrossfadeTailPlayer();
+          restoreTrackPlayerVolume();
+          crossfadeInProgressRef.current = false;
+        }
+      );
+    } catch (err) {
+      console.warn('Crossfade failed', err);
+      if (crossfadeRunIdRef.current === runId) {
+        releaseCrossfadeTailPlayer();
+        restoreTrackPlayerVolume();
+        crossfadeInProgressRef.current = false;
+      }
+    }
+  }, [
+    clearFadeTimeouts,
+    hasNextCrossfadeTarget,
+    releaseCrossfadeTailPlayer,
+    restoreTrackPlayerVolume,
+    scheduleCrossfadeVolumes,
+  ]);
+
   const clearPlaybackState = useCallback(() => {
+    cancelCrossfade();
     queueRef.current = [];
     originalQueueRef.current = null;
     currentIndexRef.current = 0;
@@ -301,7 +520,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     bumpQueue();
     TrackPlayer.stop();
     TrackPlayer.clear();
-  }, [bumpQueue]);
+  }, [bumpQueue, cancelCrossfade]);
 
   const removeFailedCurrentTrack = useCallback(() => {
     const failedIndex = currentIndexRef.current;
@@ -388,6 +607,56 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     return () => subscription.remove();
   }, []);
 
+  useEffect(() => {
+    if (!crossfadeEnabled) {
+      cancelCrossfade();
+      return;
+    }
+
+    const interval = setInterval(() => {
+      if (
+        activeDevice ||
+        isGoogleCastConnected ||
+        crossfadeInProgressRef.current ||
+        !crossfadeEnabledRef.current ||
+        !isPlayingRef.current ||
+        repeatModeRef.current === 'one' ||
+        !hasNextCrossfadeTarget()
+      ) {
+        return;
+      }
+
+      const { position, duration } = TrackPlayer.getProgress();
+      const fadeDuration = crossfadeDurationSecondsRef.current;
+      if (
+        !Number.isFinite(position) ||
+        !Number.isFinite(duration) ||
+        position <= 0 ||
+        duration <= fadeDuration + 1
+      ) {
+        return;
+      }
+
+      const remaining = duration - position;
+      if (remaining > 0 && remaining <= fadeDuration) {
+        void startCrossfadeToNext();
+      }
+    }, CROSSFADE_POLL_INTERVAL_MS);
+
+    return () => {
+      clearInterval(interval);
+      cancelCrossfade();
+    };
+  }, [
+    activeDevice,
+    cancelCrossfade,
+    crossfadeEnabled,
+    crossfadeDurationSeconds,
+    hasNextCrossfadeTarget,
+    isGoogleCastConnected,
+    startCrossfadeToNext,
+  ]);
+
   // Build a song lookup map from the library for queue reconciliation
   const librarySongByIdRef = useRef<Map<string, Song>>(new Map());
 
@@ -463,6 +732,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   resolvePlayableSongRef.current = resolvePlayableSong;
 
   const loadQueue = useCallback(async (songs: Song[], startIndex: number, play = true, seekToPosition?: number) => {
+    cancelCrossfade();
     assertPlayableSongs(songs);
     resetLastScrobbled();
     scrobbleStartTimeRef.current = Date.now();
@@ -474,7 +744,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     );
     if (seekToPosition !== undefined && seekToPosition > 0) TrackPlayer.seekTo(seekToPosition);
     if (play) TrackPlayer.play();
-  }, [resetLastScrobbled]);
+  }, [cancelCrossfade, resetLastScrobbled]);
 
   const playSong = useCallback(async (song: Song) => {
     const playableSong = resolvePlayableSong(song);
@@ -548,6 +818,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   }, [bumpQueue, resolvePlayableSong]);
 
   const skipToNext = useCallback(async () => {
+    cancelCrossfade();
     await scrobbleIfNeededRef.current(currentSongRef.current, {
       listenedSeconds: Math.floor(TrackPlayer.getProgress().position),
       startTime: scrobbleStartTimeRef.current,
@@ -556,9 +827,10 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     if (nextIdx >= queueRef.current.length && repeatModeRef.current !== 'all') return;
     TrackPlayer.skipToNext();
     if (isPlayingRef.current) TrackPlayer.play();
-  }, []);
+  }, [cancelCrossfade]);
 
   const skipToPrevious = useCallback(async () => {
+    cancelCrossfade();
     await scrobbleIfNeededRef.current(currentSongRef.current, {
       listenedSeconds: Math.floor(TrackPlayer.getProgress().position),
       startTime: scrobbleStartTimeRef.current,
@@ -566,9 +838,10 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     if (currentIndexRef.current <= 0) return;
     TrackPlayer.skipToIndex(currentIndexRef.current - 1);
     if (isPlayingRef.current) TrackPlayer.play();
-  }, []);
+  }, [cancelCrossfade]);
 
   const skipTo = useCallback(async (index: number) => {
+    cancelCrossfade();
     const song = queueRef.current[index];
     if (!song) return;
     if (index !== currentIndexRef.current) {
@@ -584,12 +857,13 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     setCurrentSong(song);
     TrackPlayer.skipToIndex(index);
     if (isPlayingRef.current) TrackPlayer.play();
-  }, []);
+  }, [cancelCrossfade]);
 
   const pauseSong = useCallback(async () => {
+    cancelCrossfade();
     TrackPlayer.pause();
     if (activeDevice) castPause();
-  }, [activeDevice, castPause]);
+  }, [activeDevice, cancelCrossfade, castPause]);
 
   const resumeSong = useCallback(async () => {
     TrackPlayer.play();
@@ -717,6 +991,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   }, []);
 
   const resetQueue = useCallback(async () => {
+    cancelCrossfade();
     await scrobbleIfNeededRef.current(currentSongRef.current, {
       listenedSeconds: Math.floor(TrackPlayer.getProgress().position),
       startTime: scrobbleStartTimeRef.current,
@@ -735,7 +1010,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     setRepeatMode('off');
     TrackPlayer.setRepeatMode(RepeatMode.Off);
     bumpQueue();
-  }, [bumpQueue, resetLastScrobbled]);
+  }, [bumpQueue, cancelCrossfade, resetLastScrobbled]);
 
   const stateValue = useMemo<PlayingStateType>(() => ({
     currentSong,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -202,7 +202,11 @@
       "showSleepTimer": "Sleep Timer",
       "showSleepTimerSubtext": "Show a sleep timer control in the player.",
       "showPlaybackSpeed": "Playback Speed",
-      "showPlaybackSpeedSubtext": "Show a speed control in the player."
+      "showPlaybackSpeedSubtext": "Show a speed control in the player.",
+      "crossfade": "Crossfade",
+      "crossfadeSubtext": "Fade between songs over {{seconds}} seconds.",
+      "crossfadeDuration": "Crossfade Duration",
+      "crossfadeSeconds": "{{seconds}} seconds"
     },
     "listenBrainz": {
       "title": "ListenBrainz",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -198,7 +198,15 @@
         }
       },
       "opusCodec": "Codec Opus",
-      "opusCodecSubtext": "Meilleure qualité que le MP3 au même débit. Nettement meilleur aux débits bas."
+      "opusCodecSubtext": "Meilleure qualité que le MP3 au même débit. Nettement meilleur aux débits bas.",
+      "showSleepTimer": "Minuteur de sommeil",
+      "showSleepTimerSubtext": "Afficher le minuteur de sommeil dans le lecteur.",
+      "showPlaybackSpeed": "Vitesse de lecture",
+      "showPlaybackSpeedSubtext": "Afficher le contrôle de vitesse dans le lecteur.",
+      "crossfade": "Fondu enchaîné",
+      "crossfadeSubtext": "Créer un fondu entre les morceaux pendant {{seconds}} s.",
+      "crossfadeDuration": "Durée du fondu",
+      "crossfadeSeconds": "{{seconds}} s"
     },
     "listenBrainz": {
       "title": "ListenBrainz",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -198,7 +198,15 @@
         }
       },
       "opusCodec": "Opusコーデック",
-      "opusCodecSubtext": "同じビットレートでMP3より高音質。低ビットレートで特に効果的。"
+      "opusCodecSubtext": "同じビットレートでMP3より高音質。低ビットレートで特に効果的。",
+      "showSleepTimer": "スリープタイマー",
+      "showSleepTimerSubtext": "プレイヤーにスリープタイマーを表示します。",
+      "showPlaybackSpeed": "再生速度",
+      "showPlaybackSpeedSubtext": "プレイヤーに速度コントロールを表示します。",
+      "crossfade": "クロスフェード",
+      "crossfadeSubtext": "{{seconds}}秒かけて曲間をフェードします。",
+      "crossfadeDuration": "クロスフェード時間",
+      "crossfadeSeconds": "{{seconds}}秒"
     },
     "listenBrainz": {
       "title": "ListenBrainz",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -198,7 +198,15 @@
         }
       },
       "opusCodec": "Opus编解码器",
-      "opusCodecSubtext": "相同比特率下音质优于MP3，在低比特率下效果尤为明显。"
+      "opusCodecSubtext": "相同比特率下音质优于MP3，在低比特率下效果尤为明显。",
+      "showSleepTimer": "睡眠定时器",
+      "showSleepTimerSubtext": "在播放器中显示睡眠定时器控制。",
+      "showPlaybackSpeed": "播放速度",
+      "showPlaybackSpeedSubtext": "在播放器中显示速度控制。",
+      "crossfade": "交叉淡化",
+      "crossfadeSubtext": "用 {{seconds}} 秒在歌曲之间淡入淡出。",
+      "crossfadeDuration": "交叉淡化时长",
+      "crossfadeSeconds": "{{seconds}} 秒"
     },
     "listenBrainz": {
       "title": "ListenBrainz",

--- a/src/screens/settings/player/index.tsx
+++ b/src/screens/settings/player/index.tsx
@@ -1,28 +1,41 @@
 import React, { useCallback, useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Slider from '@react-native-community/slider';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import SettingsScreen from '../components/SettingsScreen';
 import SettingsToggleGroup from '../components/SettingsToggleGroup';
 import StreamingQuality from './components/StreamingQuality';
 import {
+  selectCrossfadeDurationSeconds,
+  selectCrossfadeEnabled,
   selectPreferredCodec,
   selectShowSleepTimer,
   selectShowPlaybackSpeed,
 } from '@/utils/redux/selectors/settingsSelectors';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import {
+  setCrossfadeEnabled,
+  setCrossfadeDurationSeconds,
   setPreferredCodec,
   setShowSleepTimer,
   setShowPlaybackSpeed,
 } from '@/utils/redux/slices/settingsSlice';
+import { useTheme } from '@/hooks/useTheme';
+
+const CROSSFADE_DURATION_MIN = 1;
+const CROSSFADE_DURATION_MAX = 12;
 
 const PlayerSettings: React.FC = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const { colors } = useTheme();
   const preferredCodec = useSelector(selectPreferredCodec);
   const activeServer = useSelector(selectActiveServer);
   const showSleepTimer = useSelector(selectShowSleepTimer);
   const showPlaybackSpeed = useSelector(selectShowPlaybackSpeed);
+  const crossfadeEnabled = useSelector(selectCrossfadeEnabled);
+  const crossfadeDurationSeconds = useSelector(selectCrossfadeDurationSeconds);
   const supportsOpus = activeServer?.type === 'jellyfin' || activeServer?.type === 'emby';
 
   const toggleOpus = useCallback((v: boolean) => { dispatch(setPreferredCodec(v ? 'opus' : 'mp3')); }, [dispatch]);
@@ -46,15 +59,87 @@ const PlayerSettings: React.FC = () => {
       value: showPlaybackSpeed,
       onValueChange: (v: boolean) => dispatch(setShowPlaybackSpeed(v)),
     },
-  ], [t, showSleepTimer, showPlaybackSpeed, dispatch]);
+    {
+      label: t('settings.player.crossfade'),
+      subtext: t('settings.player.crossfadeSubtext', { seconds: crossfadeDurationSeconds }),
+      value: crossfadeEnabled,
+      onValueChange: (v: boolean) => dispatch(setCrossfadeEnabled(v)),
+    },
+  ], [t, showSleepTimer, showPlaybackSpeed, crossfadeEnabled, crossfadeDurationSeconds, dispatch]);
+
+  const setCrossfadeDuration = useCallback((value: number) => {
+    dispatch(setCrossfadeDurationSeconds(Math.round(value)));
+  }, [dispatch]);
 
   return (
     <SettingsScreen title={t('settings.player.title')}>
       <StreamingQuality />
       {supportsOpus && <SettingsToggleGroup items={opusItems} />}
       <SettingsToggleGroup items={playerControlItems} />
+      {crossfadeEnabled && (
+        <View style={[styles.sliderCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+          <View style={styles.sliderHeader}>
+            <Text style={[styles.sliderLabel, { color: colors.secondary }]}>
+              {t('settings.player.crossfadeDuration')}
+            </Text>
+            <Text style={[styles.sliderValue, { color: colors.themeColor }]}>
+              {t('settings.player.crossfadeSeconds', { seconds: crossfadeDurationSeconds })}
+            </Text>
+          </View>
+          <Slider
+            value={crossfadeDurationSeconds}
+            minimumValue={CROSSFADE_DURATION_MIN}
+            maximumValue={CROSSFADE_DURATION_MAX}
+            step={1}
+            minimumTrackTintColor={colors.themeColor}
+            maximumTrackTintColor={colors.muted}
+            thumbTintColor={colors.themeColor}
+            onValueChange={setCrossfadeDuration}
+          />
+          <View style={styles.sliderBounds}>
+            <Text style={[styles.sliderBoundText, { color: colors.subtext }]}>
+              {t('settings.player.crossfadeSeconds', { seconds: CROSSFADE_DURATION_MIN })}
+            </Text>
+            <Text style={[styles.sliderBoundText, { color: colors.subtext }]}>
+              {t('settings.player.crossfadeSeconds', { seconds: CROSSFADE_DURATION_MAX })}
+            </Text>
+          </View>
+        </View>
+      )}
     </SettingsScreen>
   );
 };
 
 export default PlayerSettings;
+
+const styles = StyleSheet.create({
+  sliderCard: {
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: 18,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  sliderHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  sliderLabel: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  sliderValue: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  sliderBounds: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 2,
+  },
+  sliderBoundText: {
+    fontSize: 12,
+  },
+});

--- a/src/utils/redux/selectors/settingsSelectors.ts
+++ b/src/utils/redux/selectors/settingsSelectors.ts
@@ -62,6 +62,15 @@ export const selectShowSleepTimer = (state: RootState): boolean =>
 export const selectShowPlaybackSpeed = (state: RootState): boolean =>
   state.settings.showPlaybackSpeed ?? true;
 
+export const selectCrossfadeEnabled = (state: RootState): boolean =>
+  state.settings.crossfadeEnabled ?? false;
+
+export const selectCrossfadeDurationSeconds = (state: RootState): number => {
+  const duration = state.settings.crossfadeDurationSeconds ?? 3;
+  const normalized = Number.isFinite(duration) ? Math.round(duration) : 3;
+  return Math.min(12, Math.max(1, normalized));
+};
+
 export const selectShowSourceHeaders = (state: RootState): boolean =>
   state.settings.showSourceHeaders ?? true;
 

--- a/src/utils/redux/slices/settingsSlice.test.ts
+++ b/src/utils/redux/slices/settingsSlice.test.ts
@@ -1,0 +1,46 @@
+import reducer, {
+  setCrossfadeDurationSeconds,
+  setCrossfadeEnabled,
+} from './settingsSlice'
+import { selectCrossfadeDurationSeconds } from '../selectors/settingsSelectors'
+
+describe('settingsSlice crossfade settings', () => {
+  it('keeps crossfade disabled by default with a three second duration', () => {
+    const state = reducer(undefined, { type: 'settings/init' })
+
+    expect(state.crossfadeEnabled).toBe(false)
+    expect(state.crossfadeDurationSeconds).toBe(3)
+  })
+
+  it('stores crossfade duration as an integer between one and twelve seconds', () => {
+    const tooLow = reducer(undefined, setCrossfadeDurationSeconds(-4))
+    expect(tooLow.crossfadeDurationSeconds).toBe(1)
+
+    const rounded = reducer(undefined, setCrossfadeDurationSeconds(7.6))
+    expect(rounded.crossfadeDurationSeconds).toBe(8)
+
+    const tooHigh = reducer(undefined, setCrossfadeDurationSeconds(20))
+    expect(tooHigh.crossfadeDurationSeconds).toBe(12)
+
+    const invalid = reducer(undefined, setCrossfadeDurationSeconds(Number.NaN))
+    expect(invalid.crossfadeDurationSeconds).toBe(3)
+  })
+
+  it('toggles crossfade independently from the selected duration', () => {
+    const withDuration = reducer(undefined, setCrossfadeDurationSeconds(9))
+    const enabled = reducer(withDuration, setCrossfadeEnabled(true))
+
+    expect(enabled.crossfadeEnabled).toBe(true)
+    expect(enabled.crossfadeDurationSeconds).toBe(9)
+  })
+
+  it('normalizes persisted crossfade duration values when reading settings', () => {
+    expect(selectCrossfadeDurationSeconds({
+      settings: { crossfadeDurationSeconds: 99 },
+    } as any)).toBe(12)
+
+    expect(selectCrossfadeDurationSeconds({
+      settings: { crossfadeDurationSeconds: 0 },
+    } as any)).toBe(1)
+  })
+})

--- a/src/utils/redux/slices/settingsSlice.ts
+++ b/src/utils/redux/slices/settingsSlice.ts
@@ -56,6 +56,8 @@ export interface SettingsState {
   /* Player controls */
   showSleepTimer: boolean;
   showPlaybackSpeed: boolean;
+  crossfadeEnabled: boolean;
+  crossfadeDurationSeconds: number;
 
   /* Sync */
   lastSyncedAt: number | null;
@@ -98,6 +100,8 @@ const initialState: SettingsState = {
 
   showSleepTimer: true,
   showPlaybackSpeed: false,
+  crossfadeEnabled: false,
+  crossfadeDurationSeconds: 3,
 
   lastSyncedAt: null,
   syncOnAppStart: true,
@@ -209,6 +213,13 @@ const settingsSlice = createSlice({
     setShowPlaybackSpeed(state, action: PayloadAction<boolean>) {
       state.showPlaybackSpeed = action.payload;
     },
+    setCrossfadeEnabled(state, action: PayloadAction<boolean>) {
+      state.crossfadeEnabled = action.payload;
+    },
+    setCrossfadeDurationSeconds(state, action: PayloadAction<number>) {
+      const duration = Number.isFinite(action.payload) ? Math.round(action.payload) : 3;
+      state.crossfadeDurationSeconds = Math.min(12, Math.max(1, duration));
+    },
 
     setLastSyncedAt(state, action: PayloadAction<number | null>) {
       state.lastSyncedAt = action.payload;
@@ -251,6 +262,8 @@ export const {
   setDeezerPlaylistRecommendationsEnabled,
   setShowSleepTimer,
   setShowPlaybackSpeed,
+  setCrossfadeEnabled,
+  setCrossfadeDurationSeconds,
   setLastSyncedAt,
   setSyncOnAppStart,
   resetSettings,


### PR DESCRIPTION
## Summary
- Add configurable crossfade playback between tracks
- Add a 1-12 second duration setting with a 3 second default
- Add player settings controls, translations, and settings coverage

## Testing
- npx tsc --noEmit --pretty false
- npx jest src/utils/redux/slices/settingsSlice.test.ts --runInBand --watchAll=false
- npx expo export --platform ios
- npx expo export --platform android
