### PR TITLE
Smart Shuffle badge fix, artist screen unowned-release split, and playback re-render fixes

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -8,6 +8,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 import 'react-native-reanimated';
+import { enableFreeze } from 'react-native-screens';
 import { PlayingProvider } from '@/contexts/PlayingContext';
 import { CastProvider } from '@/contexts/CastContext';
 import { LibraryProvider } from '@/contexts/LibraryContext';
@@ -41,6 +42,14 @@ onlineManager.setEventListener(setOnline => {
     setOnline(!!state.isConnected)
   })
 })
+
+// Stack.Screen entries under (home) (albumView, artistView, playlistView,
+// settings, genreView) don't set freezeOnBlur explicitly, so they fall back
+// to this global flag — without it, screens left behind on the stack (e.g.
+// an artist view still mounted under a pushed album view) keep re-rendering
+// instead of pausing. The (tabs) navigator sets freezeOnBlur explicitly and
+// doesn't depend on this.
+enableFreeze(true);
 
 SplashScreen.preventAutoHideAsync();
 

--- a/src/components/rows/ExternalAlbumRow/index.tsx
+++ b/src/components/rows/ExternalAlbumRow/index.tsx
@@ -5,29 +5,22 @@ import {
   Text,
   StyleSheet,
 } from 'react-native';
-import { Link, ArrowDownCircle, Cloud } from 'lucide-react-native';
+import { Link, ArrowDownCircle } from 'lucide-react-native';
 
 import { ExternalAlbumBase } from '@/types';
 import ExternalAlbumOptions from '@/components/options/ExternalAlbumOptions';
 import MediaListRow from '@/components/MediaListRow';
-import { useTheme } from '@/hooks/useTheme';
 import { useExternalAlbumStatus } from '@/hooks/useExternalAlbumStatus';
 
 type Props = {
   album: ExternalAlbumBase;
   onPress?: (album: ExternalAlbumBase) => void;
-  /** Show a "not in your library" glyph for the common case (status.kind === 'none').
-   * Only meaningful where local and external rows can appear side by side in
-   * the same list — e.g. the merged Discography — since elsewhere (Search's
-   * source-grouped results) every row is already known to be external. */
-  showExternalBadge?: boolean;
   /** Replaces the album's own subtext line, e.g. the release year in the
    * artist screen's chronological discography. */
   subtextOverride?: string;
 };
 
-const ExternalAlbumRow: React.FC<Props> = ({ album, onPress, showExternalBadge, subtextOverride }) => {
-  const { colors } = useTheme();
+const ExternalAlbumRow: React.FC<Props> = ({ album, onPress, subtextOverride }) => {
   const status = useExternalAlbumStatus(album);
 
   const handlePress = useCallback(() => onPress?.(album), [onPress, album]);
@@ -40,8 +33,6 @@ const ExternalAlbumRow: React.FC<Props> = ({ album, onPress, showExternalBadge, 
         <ArrowDownCircle size={12} color={statusColor.downloading} />
         <Text style={[styles.badgeText, styles.badgeTextBlue]}>{status.progress}%</Text>
       </View>
-    ) : status.kind === 'none' && showExternalBadge ? (
-      <Cloud size={14} color={colors.subtext} />
     ) : null;
 
   return (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -323,7 +323,7 @@
     },
     "audiomuse": {
       "title": "AudioMuse-AI",
-      "credentialsHelper": "Connect to a self-hosted AudioMuse-AI instance pointed at this server for sonic-analysis-based Smart Shuffle and Smooth Transitions.",
+      "credentialsHelper": "Connect to a self-hosted AudioMuse-AI instance pointed at this server for sonic-analysis-based Smart Shuffle.",
       "serverUrl": "Server URL",
       "serverUrlPlaceholder": "http://audiomuse:8000",
       "apiToken": "API Token",
@@ -331,7 +331,7 @@
       "connectivity": "Connectivity",
       "connectionFailed": "AudioMuse-AI connection failed",
       "enable": "Enable AudioMuse-AI",
-      "enableSubtext": "Use AudioMuse-AI for Smart Shuffle and Smooth Transitions when connected.",
+      "enableSubtext": "Use AudioMuse-AI for Smart Shuffle when connected.",
       "disconnect": "Disconnect",
       "disconnected": "Disconnected from AudioMuse-AI."
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -502,7 +502,8 @@
       "similarArtists": "Similar artists",
       "bio": "About"
     },
-    "showMore": "{{count}} more"
+    "showMore": "{{count}} more",
+    "showUnowned": "{{count}} you don't own"
   },
   "album": {
     "disc": "Disc {{number}}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -306,7 +306,7 @@
     },
     "audiomuse": {
       "title": "AudioMuse-AI",
-      "credentialsHelper": "Connectez-vous à une instance AudioMuse-AI auto-hébergée pointant vers ce serveur pour une Lecture aléatoire intelligente et des Transitions fluides basées sur l'analyse sonore.",
+      "credentialsHelper": "Connectez-vous à une instance AudioMuse-AI auto-hébergée pointant vers ce serveur pour une Lecture aléatoire intelligente basée sur l'analyse sonore.",
       "serverUrl": "URL du serveur",
       "serverUrlPlaceholder": "http://audiomuse:8000",
       "apiToken": "Jeton API",
@@ -314,7 +314,7 @@
       "connectivity": "Connectivité",
       "connectionFailed": "Échec de la connexion à AudioMuse-AI",
       "enable": "Activer AudioMuse-AI",
-      "enableSubtext": "Utiliser AudioMuse-AI pour la Lecture aléatoire intelligente et les Transitions fluides une fois connecté.",
+      "enableSubtext": "Utiliser AudioMuse-AI pour la Lecture aléatoire intelligente une fois connecté.",
       "disconnect": "Déconnecter",
       "disconnected": "Déconnecté d'AudioMuse-AI."
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -549,7 +549,8 @@
       "similarArtists": "Artistes similaires",
       "bio": "À propos"
     },
-    "showMore": "{{count}} de plus"
+    "showMore": "{{count}} de plus",
+    "showUnowned": "{{count}} que vous ne possédez pas"
   },
   "explore": {
     "sections": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -548,7 +548,8 @@
       "similarArtists": "似ているアーティスト",
       "bio": "概要"
     },
-    "showMore": "あと{{count}}件"
+    "showMore": "あと{{count}}件",
+    "showUnowned": "未所持の{{count}}件"
   },
   "explore": {
     "sections": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -305,7 +305,7 @@
     },
     "audiomuse": {
       "title": "AudioMuse-AI",
-      "credentialsHelper": "このサーバーに接続されたセルフホストのAudioMuse-AIインスタンスに接続すると、音響解析に基づくスマートシャッフルとスムーズな切り替えが利用できます。",
+      "credentialsHelper": "このサーバーに接続されたセルフホストのAudioMuse-AIインスタンスに接続すると、音響解析に基づくスマートシャッフルが利用できます。",
       "serverUrl": "サーバーURL",
       "serverUrlPlaceholder": "http://audiomuse:8000",
       "apiToken": "APIトークン",
@@ -313,7 +313,7 @@
       "connectivity": "接続状況",
       "connectionFailed": "AudioMuse-AIへの接続に失敗しました",
       "enable": "AudioMuse-AIを有効にする",
-      "enableSubtext": "接続時にスマートシャッフルとスムーズな切り替えにAudioMuse-AIを使用します。",
+      "enableSubtext": "接続時にスマートシャッフルにAudioMuse-AIを使用します。",
       "disconnect": "切断",
       "disconnected": "AudioMuse-AIから切断しました。"
     },

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -305,7 +305,7 @@
     },
     "audiomuse": {
       "title": "AudioMuse-AI",
-      "credentialsHelper": "连接到指向此服务器的自托管 AudioMuse-AI 实例，以启用基于声音分析的智能随机播放和平滑过渡。",
+      "credentialsHelper": "连接到指向此服务器的自托管 AudioMuse-AI 实例，以启用基于声音分析的智能随机播放。",
       "serverUrl": "服务器地址",
       "serverUrlPlaceholder": "http://audiomuse:8000",
       "apiToken": "API 令牌",
@@ -313,7 +313,7 @@
       "connectivity": "连接状态",
       "connectionFailed": "连接 AudioMuse-AI 失败",
       "enable": "启用 AudioMuse-AI",
-      "enableSubtext": "连接后使用 AudioMuse-AI 实现智能随机播放和平滑过渡。",
+      "enableSubtext": "连接后使用 AudioMuse-AI 实现智能随机播放。",
       "disconnect": "断开连接",
       "disconnected": "已断开与 AudioMuse-AI 的连接。"
     },

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -548,7 +548,8 @@
       "similarArtists": "相似歌手",
       "bio": "简介"
     },
-    "showMore": "还有 {{count}} 个"
+    "showMore": "还有 {{count}} 个",
+    "showUnowned": "你未拥有的 {{count}} 个"
   },
   "explore": {
     "sections": {

--- a/src/screens/artist/components/Content/index.tsx
+++ b/src/screens/artist/components/Content/index.tsx
@@ -3,7 +3,7 @@ import { statusColor } from '@/constants/design'
 import { Platform, StyleSheet, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native'
 import { FlashList } from '@shopify/flash-list'
 import { useNavigation } from '@react-navigation/native'
-import { Ellipsis } from 'lucide-react-native'
+import { Ellipsis, Globe } from 'lucide-react-native'
 import type { AlbumBase, Artist, ExternalAlbumBase, ExternalArtist, ExternalArtistBase } from '@/types'
 import AlbumRow from '@/components/rows/AlbumRow'
 import ExternalAlbumRow from '@/components/rows/ExternalAlbumRow'
@@ -40,6 +40,7 @@ type ArtistContentItem =
   | { kind: 'localAlbum'; id: string; album: AlbumBase }
   | { kind: 'externalAlbum'; id: string; album: ExternalAlbumBase }
   | { kind: 'showMore'; id: string; target: 'albums' | 'singles'; remaining: number }
+  | { kind: 'showUnowned'; id: string; target: 'albums' | 'singles'; count: number }
   | { kind: 'similar'; id: string }
   | { kind: 'bio'; id: string }
 
@@ -189,6 +190,8 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
   const { t } = useTranslation()
   const [visibleAlbumsCount, setVisibleAlbumsCount] = useState(INITIAL_RELEASE_ROWS)
   const [visibleSinglesCount, setVisibleSinglesCount] = useState(INITIAL_RELEASE_ROWS)
+  const [showUnownedAlbums, setShowUnownedAlbums] = useState(false)
+  const [showUnownedSingles, setShowUnownedSingles] = useState(false)
   const localAlbums = useArtistAlbums(localArtist?.id ?? '')
   const { tracks: libraryTracks } = useTracks()
   const { data: externalDiscography } = useArtistExternalDiscography(localArtist?.name ?? null, !!localArtist)
@@ -211,38 +214,55 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
       const albums = localAlbums.filter(album => !isSingleOrEp(album, songCountByAlbumId.get(album.id) ?? 0))
       const singles = localAlbums.filter(album => isSingleOrEp(album, songCountByAlbumId.get(album.id) ?? 0))
 
-      // Owned releases merged chronologically with whatever the enabled
-      // external sources have for this artist that isn't already matched to
-      // something owned — the row itself (ExternalAlbumRow) double-checks
+      // Owned and unowned releases are kept in separate groups rather than
+      // merged chronologically — the row itself (ExternalAlbumRow) double-checks
       // "already in library" independently as a safety net if this dedup
-      // misses an edge case.
+      // misses an edge case. Unowned releases stay behind a "show unowned" tile
+      // (reusing the pagination row's look) until the user opts in, so scanning
+      // what you actually own isn't interrupted by releases you don't have.
       const missingAlbums = (externalDiscography?.albums ?? [])
         .filter(ext => !matchAlbumToLibrary(ext, localAlbums))
       const missingSingles = (externalDiscography?.singles ?? [])
         .filter(ext => !matchAlbumToLibrary(ext, localAlbums))
 
-      const albumItems: ArtistContentItem[] = [
-        ...albums.map(album => ({ kind: 'localAlbum' as const, id: `album-${album.id}`, album })),
-        ...missingAlbums.map(album => ({ kind: 'externalAlbum' as const, id: `album-ext-${album.id}`, album })),
-      ].sort((a, b) => compareByReleaseYearDesc(a.album, b.album))
-      const singleItems: ArtistContentItem[] = [
-        ...singles.map(album => ({ kind: 'localAlbum' as const, id: `single-${album.id}`, album })),
-        ...missingSingles.map(album => ({ kind: 'externalAlbum' as const, id: `single-ext-${album.id}`, album })),
-      ].sort((a, b) => compareByReleaseYearDesc(a.album, b.album))
+      const ownedAlbumItems: ArtistContentItem[] = albums
+        .map(album => ({ kind: 'localAlbum' as const, id: `album-${album.id}`, album }))
+        .sort((a, b) => compareByReleaseYearDesc(a.album, b.album))
+      const ownedSingleItems: ArtistContentItem[] = singles
+        .map(album => ({ kind: 'localAlbum' as const, id: `single-${album.id}`, album }))
+        .sort((a, b) => compareByReleaseYearDesc(a.album, b.album))
+      const unownedAlbumItems: ArtistContentItem[] = missingAlbums
+        .map(album => ({ kind: 'externalAlbum' as const, id: `album-ext-${album.id}`, album }))
+        .sort((a, b) => compareByReleaseYearDesc(a.album, b.album))
+      const unownedSingleItems: ArtistContentItem[] = missingSingles
+        .map(album => ({ kind: 'externalAlbum' as const, id: `single-ext-${album.id}`, album }))
+        .sort((a, b) => compareByReleaseYearDesc(a.album, b.album))
 
-      if (albumItems.length > 0) {
+      if (ownedAlbumItems.length > 0 || unownedAlbumItems.length > 0) {
         rows.push({ kind: 'section', id: 'albums-section', title: t('artist.sections.albums') })
-        rows.push(...albumItems.slice(0, visibleAlbumsCount))
-        if (visibleAlbumsCount < albumItems.length) {
-          rows.push({ kind: 'showMore', id: 'show-more-albums', target: 'albums', remaining: albumItems.length - visibleAlbumsCount })
+        rows.push(...ownedAlbumItems.slice(0, visibleAlbumsCount))
+        if (visibleAlbumsCount < ownedAlbumItems.length) {
+          rows.push({ kind: 'showMore', id: 'show-more-albums', target: 'albums', remaining: ownedAlbumItems.length - visibleAlbumsCount })
+        } else if (unownedAlbumItems.length > 0) {
+          if (showUnownedAlbums) {
+            rows.push(...unownedAlbumItems)
+          } else {
+            rows.push({ kind: 'showUnowned', id: 'show-unowned-albums', target: 'albums', count: unownedAlbumItems.length })
+          }
         }
       }
 
-      if (singleItems.length > 0) {
+      if (ownedSingleItems.length > 0 || unownedSingleItems.length > 0) {
         rows.push({ kind: 'section', id: 'singles-section', title: t('artist.sections.singles') })
-        rows.push(...singleItems.slice(0, visibleSinglesCount))
-        if (visibleSinglesCount < singleItems.length) {
-          rows.push({ kind: 'showMore', id: 'show-more-singles', target: 'singles', remaining: singleItems.length - visibleSinglesCount })
+        rows.push(...ownedSingleItems.slice(0, visibleSinglesCount))
+        if (visibleSinglesCount < ownedSingleItems.length) {
+          rows.push({ kind: 'showMore', id: 'show-more-singles', target: 'singles', remaining: ownedSingleItems.length - visibleSinglesCount })
+        } else if (unownedSingleItems.length > 0) {
+          if (showUnownedSingles) {
+            rows.push(...unownedSingleItems)
+          } else {
+            rows.push({ kind: 'showUnowned', id: 'show-unowned-singles', target: 'singles', count: unownedSingleItems.length })
+          }
         }
       }
 
@@ -279,7 +299,7 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
     }
 
     return rows
-  }, [localArtist, externalArtist, localAlbums, externalDiscography, songCountByAlbumId, visibleAlbumsCount, visibleSinglesCount, t])
+  }, [localArtist, externalArtist, localAlbums, externalDiscography, songCountByAlbumId, visibleAlbumsCount, visibleSinglesCount, showUnownedAlbums, showUnownedSingles, t])
 
   const renderItem = useCallback(({ item }: { item: ArtistContentItem }) => {
     if (item.kind === 'mostPlayed') {
@@ -320,21 +340,34 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
         : <ExternalSimilarArtistsSection similarArtists={externalArtist?.similarArtists ?? []} />
     }
 
-    if (item.kind === 'showMore') {
+    // Same tile-row look for both: "keep reading the list" (showMore) and
+    // "opt into releases you don't own" (showUnowned) are both progressive
+    // disclosure of more rows, just with different icon/copy/trigger.
+    if (item.kind === 'showMore' || item.kind === 'showUnowned') {
+      const isUnowned = item.kind === 'showUnowned'
       return (
         <TouchableOpacity
           style={styles.showMoreRow}
           onPress={() => {
-            if (item.target === 'albums') setVisibleAlbumsCount(c => c + 5)
-            else setVisibleSinglesCount(c => c + 5)
+            if (isUnowned) {
+              if (item.target === 'albums') setShowUnownedAlbums(true)
+              else setShowUnownedSingles(true)
+            } else if (item.target === 'albums') {
+              setVisibleAlbumsCount(c => c + 5)
+            } else {
+              setVisibleSinglesCount(c => c + 5)
+            }
           }}
           activeOpacity={0.65}
         >
           <View style={[styles.showMoreIcon, { backgroundColor: colors.card }]}>
-            <Ellipsis size={18} color={colors.secondary} />
+            {isUnowned
+              ? <Globe size={18} color={colors.secondary} />
+              : <Ellipsis size={18} color={colors.secondary} />
+            }
           </View>
           <Text style={[styles.showMoreText, { color: colors.secondary }]}>
-            {t('artist.showMore', { count: item.remaining })}
+            {isUnowned ? t('artist.showUnowned', { count: item.count }) : t('artist.showMore', { count: item.remaining })}
           </Text>
         </TouchableOpacity>
       )
@@ -354,11 +387,10 @@ export default function ArtistContent({ localArtist, externalArtist }: Props) {
       <ExternalAlbumRow
         album={item.album}
         onPress={(album) => navigateToAlbum(album)}
-        showExternalBadge={!!localArtist}
         subtextOverride={releaseYearLabel(item.album) ?? undefined}
       />
     )
-  }, [colors, localArtist, externalArtist, navigation, navigateToAlbum, setVisibleAlbumsCount, setVisibleSinglesCount, t])
+  }, [colors, localArtist, externalArtist, navigation, navigateToAlbum, setVisibleAlbumsCount, setVisibleSinglesCount, setShowUnownedAlbums, setShowUnownedSingles, t])
 
   return (
     <View style={{ flex: 1 }}>

--- a/src/screens/playing/components/Controls.tsx
+++ b/src/screens/playing/components/Controls.tsx
@@ -58,8 +58,14 @@ function ToggleButton({
       <TouchableOpacity onPress={onPress} hitSlop={HIT_SLOP}>
         {children}
       </TouchableOpacity>
-      {badge === 'dot' && <View style={[styles.activeDot, styles.activeDotVisible]} />}
-      {badge === 'sparkle' && <Sparkle size={9} color="#fff" fill="#fff" style={styles.activeBadge} />}
+      {badge !== 'none' && (
+        <View style={styles.activeBadgeSlot}>
+          {badge === 'dot'
+            ? <View style={[styles.activeDot, styles.activeDotVisible]} />
+            : <Sparkle size={9} color="#fff" fill="#fff" />
+          }
+        </View>
+      )}
     </View>
   );
 }
@@ -123,20 +129,22 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     minWidth: 28,
   },
+  activeBadgeSlot: {
+    position: 'absolute',
+    bottom: -5,
+    width: 4,
+    height: 4,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   activeDot: {
     width: 4,
     height: 4,
     borderRadius: 2,
     backgroundColor: 'transparent',
-    position: 'absolute',
-    bottom: -5,
   },
   activeDotVisible: {
     backgroundColor: '#fff',
-  },
-  activeBadge: {
-    position: 'absolute',
-    bottom: -5,
   },
 });
 

--- a/src/screens/playing/components/PlayingMain.tsx
+++ b/src/screens/playing/components/PlayingMain.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import {
   View,
   Text,
@@ -28,6 +28,40 @@ const formatTime = (seconds: number): string => {
   return `${mins}:${secs < 10 ? '0' : ''}${secs}`;
 };
 
+// Isolated so the once-a-second progress tick only re-renders the seek bar
+// and timestamps, not the cover art / title / artist / add button above it —
+// same reasoning as ProgressBarStrip in the mini player (PlayingBarBase).
+const PlayingProgressSection: React.FC<{ songDuration: number }> = memo(({ songDuration }) => {
+  const { seekSong } = usePlayingActions();
+  const progress = usePlayingProgress();
+  const nativeDuration = progress.duration;
+  const duration = nativeDuration > 0 ? nativeDuration : songDuration;
+  const position = Math.min(progress.position, duration);
+
+  return (
+    <>
+      <SeekableProgressBar
+        value={position}
+        duration={duration}
+        onSeek={seekSong}
+        fillColor="#fff"
+        trackColor="#555"
+        style={styles.progressBar}
+      />
+
+      <View style={styles.timestamps}>
+        <Text style={styles.timestamp}>
+          {formatTime(position)}
+        </Text>
+        <Text style={styles.timestamp}>
+          -{formatTime(duration - position)}
+        </Text>
+      </View>
+    </>
+  );
+});
+PlayingProgressSection.displayName = 'PlayingProgressSection';
+
 const PlayingMain: React.FC<PlayingMainProps> = ({
   width,
   onPressArtist,
@@ -35,13 +69,7 @@ const PlayingMain: React.FC<PlayingMainProps> = ({
   onPressAdd
 }) => {
   const { currentSong } = usePlayingState();
-  const { seekSong } = usePlayingActions();
   const showQualityBadge = useSelector(selectShowQualityBadge);
-  const progress = usePlayingProgress();
-  const nativeDuration = progress.duration
-  const songDuration = currentSong ? Number(currentSong.duration) : 1
-  const duration = nativeDuration > 0 ? nativeDuration : songDuration
-  const position = Math.min(progress.position, duration)
 
   if (!currentSong) {
     return null;
@@ -61,10 +89,6 @@ const PlayingMain: React.FC<PlayingMainProps> = ({
   const coverUri =
     buildCover(currentSong.cover, 'detail') ??
     buildCover({ kind: 'none' } as CoverSource, 'detail');
-
-  const handleSeek = (positionSeconds: number) => {
-    seekSong(positionSeconds);
-  };
 
   return (
     <View style={[styles.root, { width }]}>
@@ -115,23 +139,7 @@ const PlayingMain: React.FC<PlayingMainProps> = ({
         </Text>
       )}
 
-      <SeekableProgressBar
-        value={position}
-        duration={duration}
-        onSeek={handleSeek}
-        fillColor="#fff"
-        trackColor="#555"
-        style={styles.progressBar}
-      />
-
-      <View style={styles.timestamps}>
-        <Text style={styles.timestamp}>
-          {formatTime(position)}
-        </Text>
-        <Text style={styles.timestamp}>
-          -{formatTime(duration - position)}
-        </Text>
-      </View>
+      <PlayingProgressSection songDuration={Number(currentSong.duration)} />
     </View>
   );
 };

--- a/src/screens/playing/index.tsx
+++ b/src/screens/playing/index.tsx
@@ -42,6 +42,27 @@ interface PlayingScreenProps {
 
 type PlayingViewMode = "player" | "queue";
 
+// Isolated so the once-a-second progress tick only re-renders this small
+// card, not the whole PlayingScreen tree (header, PlayingMain, Controls,
+// BottomControls, and the other cards) — that tree stays mounted the entire
+// time a song is playing, hidden behind the collapsed player sheet, so an
+// unnecessary full re-render every second was a constant, avoidable cost.
+const LyricsPreviewCardResolver: React.FC<{
+    lyrics: LyricsResult;
+    contentWidth: number;
+    onPress: () => void;
+}> = ({ lyrics, contentWidth, onPress }) => {
+    const progress = usePlayingProgress();
+    return (
+        <LyricsPreviewCard
+            lyrics={lyrics}
+            position={progress.position}
+            contentWidth={contentWidth}
+            onPress={onPress}
+        />
+    );
+};
+
 const usePlayingTransitions = (mode: PlayingViewMode) => {
     const playerOpacity = useSharedValue(1);
     const queueOpacity = useSharedValue(0);
@@ -80,7 +101,6 @@ const PlayingScreen: React.FC<PlayingScreenProps> = ({
 }) => {
     const router = useRouter();
     const { currentSong } = usePlayingState();
-    const progress = usePlayingProgress();
     const api = useApi();
     const insets = useSafeAreaInsets();
     const { album } = useAlbum(currentSong?.albumId ?? '');
@@ -236,9 +256,8 @@ const PlayingScreen: React.FC<PlayingScreenProps> = ({
                             </View>
 
                             {lyricsAvailable && lyrics && (
-                                <LyricsPreviewCard
+                                <LyricsPreviewCardResolver
                                     lyrics={lyrics}
-                                    position={progress.position}
                                     contentWidth={contentWidth}
                                     onPress={openLyricsSheet}
                                 />


### PR DESCRIPTION
## Summary
Four follow-ups on top of #172/#173/#174:

- **Smart Shuffle badge alignment**: the sparkle badge sat slightly higher than the plain dot for regular Shuffle — both anchored to `bottom: -5`, but the dot is 4px tall and the sparkle glyph is 9px, so their visual centers were a few pixels apart. Both now render inside a shared 4×4 positioned slot that centers its child, landing on the same point regardless of the badge glyph's own size.
- **Artist screen — separate owned and unowned releases**: owned and external (not-in-library) releases were merged into one chronological list, distinguished only by a small subtext-line cloud icon. Owned releases now come first (same pagination as before); once exhausted, unowned releases sit behind a "N you don't own" tile that reuses the existing show-more row's look (same icon tile, same text row) with a `Globe` icon and its own trigger. The per-row cloud badge is gone — the tile itself carries that meaning now.
- **AudioMuse-AI settings copy**: dropped the "Smooth Transitions" mention — that feature was never implemented (just unused scaffolding in `playingQueue.ts`). Both `credentialsHelper` and `enableSubtext` now only reference Smart Shuffle, across all four locales.
- **Playing screen re-render fix**: `PlayingScreen` and `PlayingMain` both subscribed to playback progress directly, so the once-a-second position tick re-rendered the entire expanded-player tree (header, cover art, title, Controls, BottomControls, every card) continuously — not just while the sheet was open, but for the whole time a song was playing, since that tree stays mounted behind the collapsed mini player the entire session. Isolated both into small memoized components that only re-render on the tick themselves, matching the pattern already used for the mini player's progress strip. Also enabled `react-native-screens`' global freeze flag, which the pushed detail screens (album/artist/playlist/settings/genre views) fall back to since they don't set `freezeOnBlur` explicitly.

## Type of change
- [x] Bug fix
- [x] Refactor / cleanup

## Testing
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npx jest --ci` — 139 tests passing (30 suites)

## Related issues
Follow-up to #172, #173, #174.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3mnXvMuRSrd1sPugbnrKQ)_