### PR TITLE
Harden Lidarr album download resolution

### DIFF
--- a/src/api/lidarr/albums/index.test.ts
+++ b/src/api/lidarr/albums/index.test.ts
@@ -366,6 +366,34 @@ describe('downloadAlbum', () => {
     expect(commandPosts).toHaveLength(1);
   });
 
+  it('still resolves when the mbid-scoped artist lookup is rejected', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockImplementationOnce(() => response([])) // local artists
+      .mockImplementationOnce(() => response(iveCandidates)) // lookup by name
+      .mockImplementationOnce(() => response('bad request', 400)) // lidarr:<mbid>
+      .mockImplementationOnce(() => response([])) // ensureArtist re-read
+      .mockImplementationOnce(() => response([{ path: '/music' }]))
+      .mockImplementationOnce(() => response({ id: 20 }))
+      .mockImplementationOnce(() => response([lidarrAlbum]))
+      .mockImplementationOnce(() =>
+        response({ ...lidarrAlbum, monitored: true })
+      )
+      .mockImplementationOnce(() => response([]))
+      .mockImplementationOnce(() => response({ id: 30 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await downloadAlbum(
+      config,
+      request({ artistMbid: 'b2f2216a-d7a9-4ce0-8b8f-f494d9a8c196' })
+    );
+
+    expect(result).toEqual({ success: true, status: 'submitted' });
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes('lidarr%3A'))
+    ).toBe(true);
+  });
+
   it('does not submit a duplicate search already active in Lidarr', async () => {
     const localArtist = {
       ...resolvedArtist,

--- a/src/api/lidarr/albums/index.ts
+++ b/src/api/lidarr/albums/index.ts
@@ -324,12 +324,17 @@ async function lookupResolvedArtist(
   const byName = await lookupArtist(client, request.artistName);
   let candidates = byName;
   if (request.artistMbid) {
-    const byMbid = await lookupArtist(client, `lidarr:${request.artistMbid}`);
-    const seen = new Set(byName.map(artist => artist.foreignArtistId));
-    candidates = [
-      ...byName,
-      ...byMbid.filter(artist => !seen.has(artist.foreignArtistId)),
-    ];
+    try {
+      const byMbid = await lookupArtist(client, `lidarr:${request.artistMbid}`);
+      const seen = new Set(byName.map(artist => artist.foreignArtistId));
+      candidates = [
+        ...byName,
+        ...byMbid.filter(artist => !seen.has(artist.foreignArtistId)),
+      ];
+    } catch {
+      // Lidarr may reject the mbid-scoped lookup term. Fall back to the name
+      // candidates rather than failing a request the name lookup can resolve.
+    }
   }
   return resolveArtistCandidate(candidates, request);
 }
@@ -345,6 +350,7 @@ async function waitForAlbum(
   }: DownloadOptions
 ): Promise<AlbumResolution | { ok: false; code: 'request_timeout' }> {
   const started = Date.now();
+  let lastResolution: AlbumResolution | null = null;
 
   while (Date.now() - started < timeoutMs) {
     if (signal?.aborted) {
@@ -356,11 +362,15 @@ async function waitForAlbum(
     if (resolution.ok || resolution.code === 'album_identity_ambiguous') {
       return resolution;
     }
+    lastResolution = resolution;
 
     await delay(pollIntervalMs, signal);
   }
 
-  return { ok: false, code: 'request_timeout' };
+  // Prefer the specific "not found" outcome from the last completed read over a
+  // generic timeout, so the user learns the album is absent from Lidarr rather
+  // than assuming a transient stall. Fall back to timeout only if no read landed.
+  return lastResolution ?? { ok: false, code: 'request_timeout' };
 }
 
 async function monitorAlbum(client: LidarrClient, album: LidarrAlbum) {
@@ -416,7 +426,7 @@ function isAlbumAvailable(album: LidarrAlbum) {
   );
 }
 
-function requestKey(request: LidarrAlbumRequest) {
+function requestKey(config: LidarrConfig, request: LidarrAlbumRequest) {
   const artist =
     cleanId(request.artistMbid) ??
     cleanId(request.artistDeezerId) ??
@@ -425,7 +435,9 @@ function requestKey(request: LidarrAlbumRequest) {
     cleanId(request.albumMbid) ??
     cleanId(request.albumDeezerId) ??
     `${normalize(request.albumTitle)}:${releaseYear(request.releaseDate) ?? ''}`;
-  return `${artist}:${album}`;
+  // Scope by server so identical album identities on different Lidarr
+  // instances are not coalesced into one shared in-flight request.
+  return `${cleanId(config.serverUrl) ?? ''}:${artist}:${album}`;
 }
 
 async function performDownload(
@@ -448,12 +460,13 @@ async function performDownload(
     });
     if (!ensured.success) return failure('lidarr_metadata_unavailable');
 
-    const albumResolution = await waitForAlbum(
-      client,
-      ensured.artistId,
-      request,
-      options
-    );
+    const albumResolution = await waitForAlbum(client, ensured.artistId, request, {
+      ...options,
+      // A pre-existing artist already has its album list, so a missing album
+      // won't appear by waiting; only a freshly created artist needs time for
+      // Lidarr to populate metadata.
+      timeoutMs: options.timeoutMs ?? (ensured.created ? 90_000 : 10_000),
+    });
     if (!albumResolution.ok) return failure(albumResolution.code);
 
     if (isAlbumAvailable(albumResolution.album)) {
@@ -487,7 +500,7 @@ export function downloadAlbum(
   request: LidarrAlbumRequest,
   options: DownloadOptions = {}
 ): Promise<AlbumSearchResult> {
-  const key = requestKey(request);
+  const key = requestKey(config, request);
   const pending = pendingRequests.get(key);
   if (pending) return pending;
 


### PR DESCRIPTION
## Summary

Follow-up hardening for the album identity resolution merged in #178. Three targeted fixes surfaced during review, each covered by the existing/new test suite.

### 1. Guard the mbid-scoped artist lookup
The `lidarr:${mbid}` lookup was unguarded: if Lidarr rejects the prefixed term, `client.request` throws and the whole download fails with `lidarr_metadata_unavailable` — even when the plain name lookup a line earlier already resolved the artist. Now wrapped in try/catch, degrading to the name candidates. Adds a regression test (previously this branch was untested).

### 2. Scope request coalescing by server
`requestKey` / `pendingRequests` were keyed only by album/artist identity. Two Lidarr instances requesting the same album identity would coalesce into one shared in-flight promise. Now keyed by `serverUrl` as well.

### 3. Faster, clearer album polling
- A pre-existing artist already has its album list, so waiting can't make a missing album appear. Freshly created artists still get the full 90s window for metadata population; existing artists now fail fast (10s).
- On poll exhaustion, return the specific `album_not_found_for_artist` outcome from the last completed read instead of a generic `request_timeout`.

## Validation

- `npx jest` — 19 suites, 80 tests passed (adds 1)
- `npx eslint src/api/lidarr/albums/index.ts` — clean
- `npx tsc --noEmit` — no new errors (pre-existing expo-router typed-route errors in `ExternalResolutionProvider.tsx` are unrelated and untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)