### PR TITLE
Fix the crossfade, and what a real build found

### DIFF
--- a/app.json
+++ b/app.json
@@ -63,7 +63,8 @@
             "deploymentTarget": "16.0"
           }
         }
-      ]
+      ],
+      "yuzic-engine"
     ],
     "experiments": {
       "typedRoutes": true

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3301,34 +3301,6 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNTPPlayer (5.6.0):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - RNWorklets (0.8.3):
     - boost
     - DoubleConversion
@@ -3556,7 +3528,6 @@ DEPENDENCIES:
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
-  - "RNTPPlayer (from `../node_modules/@rntp/player`)"
   - RNWorklets (from `../node_modules/react-native-worklets`)
   - SocketRocket (~> 0.7.1)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -3820,8 +3791,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-screens"
   RNSVG:
     :path: "../node_modules/react-native-svg"
-  RNTPPlayer:
-    :path: "../node_modules/@rntp/player"
   RNWorklets:
     :path: "../node_modules/react-native-worklets"
   Yoga:
@@ -3958,7 +3927,6 @@ SPEC CHECKSUMS:
   RNReanimated: 4e6187f2ba1e30e6ddc7c8fc9f19b2dd2b6b2532
   RNScreens: afaf526a9c804c3b4503f950cf3e67ed81e29ada
   RNSVG: 595abfa0f9ac26d56afcaaedf4e37a00f54cab71
-  RNTPPlayer: d2adebcdf06d20aa617c42f6c11fbc8ff99aa43f
   RNWorklets: 534af667da0c0049e0060ae43f03c7df8cc9a6e0
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
@@ -3966,7 +3934,7 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: b669e79fa0f8d3f6f5e35372345f54b99e06b13c
-  YuzicEngine: b3f15657f1a26d23ef4c2c34e8846e756d7bd9e0
+  YuzicEngine: b7f146752ba1b5e2b03dfb348535944d4d51fab6
 
 PODFILE CHECKSUM: 0a9d7fe2b7d7051d8f049cc799931b185ca60dc3
 

--- a/ios/Yuzic/Info.plist
+++ b/ios/Yuzic/Info.plist
@@ -76,9 +76,9 @@
 					<key>UISceneClassName</key>
 					<string>CPTemplateApplicationScene</string>
 					<key>UISceneConfigurationName</key>
-					<string>CarPlay</string>
+					<string>YuzicEngineCarPlay</string>
 					<key>UISceneDelegateClassName</key>
-					<string>RNTPCarPlaySceneDelegate</string>
+					<string>YuzicCarPlaySceneDelegate</string>
 				</dict>
 			</array>
 			<key>UIWindowSceneSessionRoleApplication</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "github:eftpmc/yuzic-engine#7d92945"
+        "yuzic-engine": "github:eftpmc/yuzic-engine#2e43968"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17945,7 +17945,7 @@
     },
     "node_modules/yuzic-engine": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/eftpmc/yuzic-engine.git#7d9294593355bd664156c16f7fa7d8784e21b02b",
+      "resolved": "git+ssh://git@github.com/eftpmc/yuzic-engine.git#2e439686b4f62e4bc5a7e0079757fb4bf49e5d32",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "github:eftpmc/yuzic-engine#2e43968"
+        "yuzic-engine": "github:eftpmc/yuzic-engine#be3a16a"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17945,7 +17945,7 @@
     },
     "node_modules/yuzic-engine": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/eftpmc/yuzic-engine.git#2e439686b4f62e4bc5a7e0079757fb4bf49e5d32",
+      "resolved": "git+ssh://git@github.com/eftpmc/yuzic-engine.git#be3a16a03cceccebbe7eea7475b689a686d834f4",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "github:eftpmc/yuzic-engine#0dfd50d"
+        "yuzic-engine": "github:eftpmc/yuzic-engine#24b8a69"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17945,7 +17945,7 @@
     },
     "node_modules/yuzic-engine": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/eftpmc/yuzic-engine.git#0dfd50d72610d690dfbf4a824fcaa31f55398d5d",
+      "resolved": "git+ssh://git@github.com/eftpmc/yuzic-engine.git#24b8a697855a67e0a646ca9f9b0ad0309a9750ab",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "github:eftpmc/yuzic-engine#24b8a69"
+        "yuzic-engine": "github:eftpmc/yuzic-engine#7d92945"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17945,7 +17945,7 @@
     },
     "node_modules/yuzic-engine": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/eftpmc/yuzic-engine.git#24b8a697855a67e0a646ca9f9b0ad0309a9750ab",
+      "resolved": "git+ssh://git@github.com/eftpmc/yuzic-engine.git#7d9294593355bd664156c16f7fa7d8784e21b02b",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "github:eftpmc/yuzic-engine#0dfd50d"
+    "yuzic-engine": "github:eftpmc/yuzic-engine#24b8a69"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "github:eftpmc/yuzic-engine#24b8a69"
+    "yuzic-engine": "github:eftpmc/yuzic-engine#7d92945"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "github:eftpmc/yuzic-engine#2e43968"
+    "yuzic-engine": "github:eftpmc/yuzic-engine#be3a16a"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "github:eftpmc/yuzic-engine#7d92945"
+    "yuzic-engine": "github:eftpmc/yuzic-engine#2e43968"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/contexts/PlayingContext.tsx
+++ b/src/contexts/PlayingContext.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/utils/redux/selectors/settingsSelectors';
 import { selectIsAudiomuseConfigured, selectAudiomuseConfig } from '@/utils/redux/selectors/audiomuseSelectors';
 import { useStreamQuality } from '@/hooks/useStreamQuality';
+import { playableQuality } from '@/utils/audio/playableFormat';
 import {
   QueueFillProvider,
   createNativeSimilarityQueueFillProvider,
@@ -769,7 +770,13 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     if (song.contentKind && song.contentKind !== 'song') return song;
     const localPath = getLocalPath(song.id);
     if (localPath) return { ...song, streamUrl: localPath };
-    const freshUrl = api.songs.buildStreamUrl(song.id, streamQualityRef.current, preferredCodecRef.current);
+    // "Original" serves the untouched file, which is the only way to hear a
+    // lossless library losslessly — and the only setting that can hand the
+    // device something it cannot decode at all. An Ogg Vorbis album played on
+    // every quality except Original, where iOS has no Vorbis decoder and the
+    // track failed outright. Transcoding it is a smaller loss than silence.
+    const quality = playableQuality(song, streamQualityRef.current);
+    const freshUrl = api.songs.buildStreamUrl(song.id, quality, preferredCodecRef.current);
     return freshUrl ? { ...song, streamUrl: freshUrl } : song;
   }, [api, getLocalPath]);
   // Keep ref in sync during render so effects/handlers always have the latest version

--- a/src/features/player/PlayerHost.tsx
+++ b/src/features/player/PlayerHost.tsx
@@ -79,9 +79,17 @@ export default function PlayerHost() {
       return;
     }
     if (!currentSong?.cover) return;
+    // `grid` (420px), not `detail` (1200px). This image is never displayed —
+    // it is downloaded, averaged into an accent gradient, and thrown away, and
+    // averaging does not get better with resolution. At `detail` the app was
+    // fetching a 1200px cover on every track change, which is the largest
+    // per-track download in the app on a phone that is often on cellular.
+    //
+    // It also 404s more: Navidrome only generates 1200 for large originals,
+    // as `buildCover` already notes for the MusicBrainz path.
     const uri =
-      buildCover(currentSong.cover, 'detail') ??
-      buildCover({ kind: 'none' }, 'detail');
+      buildCover(currentSong.cover, 'grid') ??
+      buildCover({ kind: 'none' }, 'grid');
     if (uri) extractColors(uri);
   }, [coverAccentEnabled, currentSong?.cover, currentSong?.id, extractColors]);
 

--- a/src/features/player/createEngineBackend.test.ts
+++ b/src/features/player/createEngineBackend.test.ts
@@ -17,6 +17,7 @@ import type { MediaItem } from './mediaItem';
 const mockCalls: { name: string; args: unknown[] }[] = [];
 let mockListener: ((event: unknown) => void) | null = null;
 let mockFailing: string | null = null;
+let mockSetupGate: Promise<void> | null = null;
 
 const mockEngine = new Proxy(
   {},
@@ -30,7 +31,11 @@ const mockEngine = new Proxy(
       }
       return (...args: unknown[]) => {
         mockCalls.push({ name, args });
-        return name === mockFailing ? Promise.reject(new Error('nope')) : Promise.resolve();
+        if (name === mockFailing) return Promise.reject(new Error('nope'));
+        // `setup` can be held open, so a test can reproduce the window in
+        // which the native graph does not exist yet.
+        if (name === 'setup' && mockSetupGate) return mockSetupGate;
+        return Promise.resolve();
       };
     },
   }
@@ -68,6 +73,7 @@ beforeEach(() => {
   mockCalls.length = 0;
   mockListener = null;
   mockFailing = null;
+  mockSetupGate = null;
   // Several tests here make calls fail on purpose, and `fire` warns on every
   // failure so a release build leaves a trace. Silenced rather than tolerated:
   // expected output that looks like a problem trains you to ignore the run.
@@ -147,6 +153,72 @@ describe('talking to the engine', () => {
     backend.setMediaItems([item('a', { url: { uri: 'file:///x.flac' } })], 0);
     const sent = named('setQueue')[0].args[0] as { uri: string; id: string }[];
     expect(sent[0]).toMatchObject({ id: 'a', uri: 'file:///x.flac' });
+  });
+});
+
+describe('the cold-launch race', () => {
+  /**
+   * The bug this prevents, reported from a TestFlight build: the app opened,
+   * showed the track, and sat paused until it was restarted.
+   *
+   * Every transport function on the native side is `self.engine?.play()`, so a
+   * call arriving before the graph exists is optional-chained into a silent
+   * no-op — no error, no event, nothing to grep for. Setup is slowest on a
+   * cold first launch, which is exactly when the restored queue issues
+   * `setMediaItems` and `play`.
+   */
+  it('holds transport calls until setup has finished', async () => {
+    let openTheGate: () => void = () => {};
+    mockSetupGate = new Promise<void>(resolve => {
+      openTheGate = resolve;
+    });
+
+    const backend = createEngineBackend();
+    backend.setup();
+    backend.setMediaItems([item('a')], 0);
+    backend.play();
+
+    await Promise.resolve();
+    expect(mockCalls.map(c => c.name)).toEqual(['setup']);
+
+    openTheGate();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(mockCalls.map(c => c.name)).toEqual(['setup', 'setQueue', 'play']);
+  });
+
+  /** Order is preserved once the gate opens — a play must not overtake a queue. */
+  it('replays the held calls in the order they were made', async () => {
+    let openTheGate: () => void = () => {};
+    mockSetupGate = new Promise<void>(resolve => {
+      openTheGate = resolve;
+    });
+
+    const backend = createEngineBackend();
+    backend.setup();
+    backend.setMediaItems([item('a')], 0);
+    backend.seekTo(30);
+    backend.play();
+
+    openTheGate();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(mockCalls.map(c => c.name)).toEqual(['setup', 'setQueue', 'seekTo', 'play']);
+  });
+
+  /**
+   * A setup that fails must not block the transport for the life of the
+   * process. It reports itself; the player should still try.
+   */
+  it('opens the gate even when setup fails', async () => {
+    mockFailing = 'setup';
+
+    const backend = createEngineBackend();
+    backend.setup();
+    backend.play();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockCalls.map(c => c.name)).toContain('play');
   });
 });
 

--- a/src/features/player/createEngineBackend.ts
+++ b/src/features/player/createEngineBackend.ts
@@ -99,18 +99,47 @@ export function createEngineBackend(): PlayerBackend {
    * imperfectly. The warning is what makes the difference visible without
    * changing that.
    */
+  /** Resolves once `setup` has settled. Null until `setup` is called. */
+  let ready: Promise<void> | null = null;
+
   function fire(what: string, run: () => Promise<unknown>) {
     const report = (error: unknown) => {
       console.warn(`[player] ${what} failed`, error);
       emit({ type: 'error', code: 'ENGINE_CALL_FAILED', message: `${what}: ${String(error)}` });
     };
-    try {
-      const result = run();
-      if (result && typeof result.catch === 'function') {
-        result.catch(report);
+
+    // Everything waits for setup, and this is not belt-and-braces: on the
+    // native side every transport function is `self.engine?.play()`, so a call
+    // arriving before the graph exists is optional-chained into a silent
+    // no-op. No error, no event, nothing in a log.
+    //
+    // That is what made the app open on a cold first launch, show the track,
+    // and sit paused: setup was still claiming the audio session and building
+    // the graph while the restored queue issued `setMediaItems` and `play`,
+    // and both went nowhere. Restarting "fixed" it because by then setup had
+    // long finished, which is exactly why it reads as flaky rather than
+    // broken.
+    //
+    // `then(next, next)` runs the call whether setup resolved or rejected: a
+    // failed setup already reports itself, and blocking the transport forever
+    // afterwards would turn a bad launch into a dead player.
+    const next = () => {
+      try {
+        const result = run();
+        if (result && typeof result.catch === 'function') {
+          result.catch(report);
+        }
+      } catch (error) {
+        report(error);
       }
-    } catch (error) {
-      report(error);
+    };
+
+    if (ready && what !== 'setup') {
+      // Callbacks queue in registration order, so calls stay in the order the
+      // app made them rather than racing each other once the gate opens.
+      ready.then(next, next);
+    } else {
+      next();
     }
   }
 
@@ -129,9 +158,22 @@ export function createEngineBackend(): PlayerBackend {
 
   return {
     setup() {
+      // Held so every later call can wait behind it. Assigned before `fire`
+      // runs the body, because `fire` reads it to decide whether to gate.
+      let settle: () => void = () => {};
+      ready = new Promise<void>(resolve => {
+        settle = resolve;
+      });
       fire('setup', async () => {
         const api = load();
-        await api.setup({ progressIntervalMs: 250 });
+        try {
+          await api.setup({ progressIntervalMs: 250 });
+        } finally {
+          // Resolved in `finally` rather than after: a setup that threw still
+          // has to open the gate, or the transport is blocked for the life of
+          // the process.
+          settle();
+        }
         // Subscribe once, and only after setup — the module has no listener
         // list before it exists.
         if (!unsubscribeEngine) {

--- a/src/screens/library/components/SortBottomSheet.tsx
+++ b/src/screens/library/components/SortBottomSheet.tsx
@@ -15,6 +15,7 @@ import { useRadius } from '@/hooks/useRadius';
 import { useTranslation } from 'react-i18next';
 import { renderBackdrop } from '@/components/BottomSheetBackdrop';
 import Touchable from '@/components/Touchable';
+import { withAlpha } from '@/features/theme/coverAccent';
 
 type SortOrder = 'title' | 'recent' | 'userplays' | 'year' | 'recentlyAdded';
 
@@ -69,7 +70,7 @@ const SortBottomSheet = forwardRef<
                 styles.pickerItem,
                 {
                   backgroundColor: isSelected
-                    ? themeColor + '22'
+                    ? withAlpha(themeColor, 0.13)
                     : 'transparent',
                   borderRadius: rad.md,
                 },

--- a/src/screens/playing/components/OutputDeviceSheet.tsx
+++ b/src/screens/playing/components/OutputDeviceSheet.tsx
@@ -24,6 +24,7 @@ import { getServerProvider } from '@/utils/servers/registry';
 import Touchable from '@/components/Touchable';
 import { iconSize, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
+import { withAlpha } from '@/features/theme/coverAccent';
 
 const {
   AirplayButton,
@@ -120,7 +121,7 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
 
         {/* This device — selected when no sink has taken the audio elsewhere */}
         <Touchable
-          style={[styles.item, { backgroundColor: isLocal ? themeColor + '22' : 'transparent', borderRadius: rad.md }]}
+          style={[styles.item, { backgroundColor: isLocal ? withAlpha(themeColor, 0.13) : 'transparent', borderRadius: rad.md }]}
           onPress={async () => {
             await selectLocal();
             (ref as React.RefObject<BottomSheetModal>).current?.dismiss();
@@ -140,7 +141,7 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
         {jukeboxAvailable && (
           <Touchable
             testID="output-jukebox"
-            style={[styles.item, { backgroundColor: sink.kind === 'jukebox' ? themeColor + '22' : 'transparent', borderRadius: rad.md }]}
+            style={[styles.item, { backgroundColor: sink.kind === 'jukebox' ? withAlpha(themeColor, 0.13) : 'transparent', borderRadius: rad.md }]}
             onPress={handleSelectJukebox}
             disabled={isSwitching}
           >
@@ -156,7 +157,7 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
 
         {/* AirPlay — iOS only */}
         {Platform.OS === 'ios' && AirplayButton && (
-          <View style={[styles.item, { backgroundColor: airplayDevice ? themeColor + '22' : 'transparent', borderRadius: rad.md }]}>
+          <View style={[styles.item, { backgroundColor: airplayDevice ? withAlpha(themeColor, 0.13) : 'transparent', borderRadius: rad.md }]}>
             <View style={styles.itemLeft}>
               <Airplay size={iconSize.row} color={airplayDevice ? themeColor : colors.subtext} />
               <Text style={[
@@ -187,7 +188,7 @@ const OutputDeviceSheet = forwardRef<BottomSheetModal>((_, ref) => {
         {/* Active DLNA device */}
         {activeDlna && (
           <Touchable
-            style={[styles.item, { backgroundColor: themeColor + '22', borderRadius: rad.md }]}
+            style={[styles.item, { backgroundColor: withAlpha(themeColor, 0.13), borderRadius: rad.md }]}
             onPress={selectLocal}
           >
             <View style={styles.itemLeft}>

--- a/src/screens/playing/components/PlaybackSpeedCard.tsx
+++ b/src/screens/playing/components/PlaybackSpeedCard.tsx
@@ -13,6 +13,7 @@ import {
 import Touchable from '@/components/Touchable';
 import { iconSize, onDark, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
+import { withAlpha } from '@/features/theme/coverAccent';
 
 type Props = { contentWidth: number };
 
@@ -45,7 +46,7 @@ export default function PlaybackSpeedCard({ contentWidth }: Props) {
       style={[
         styles.card,
         { width: contentWidth, borderRadius: rad.panel },
-        isAltered && { borderColor: themeColor + '55', borderWidth: 1 },
+        isAltered && { borderColor: withAlpha(themeColor, 0.33), borderWidth: 1 },
       ]}
     >
       {/* Decorative gauge */}

--- a/src/screens/playing/components/SleepTimerCard.tsx
+++ b/src/screens/playing/components/SleepTimerCard.tsx
@@ -14,6 +14,7 @@ import {
 import Touchable from '@/components/Touchable';
 import { iconSize, onDark, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
+import { withAlpha } from '@/features/theme/coverAccent';
 
 function formatCountdown(seconds: number): string {
   const m = Math.floor(seconds / 60);
@@ -103,7 +104,7 @@ export default function SleepTimerCard({ contentWidth }: Props) {
       style={[
         styles.card,
         { width: contentWidth, borderRadius: rad.panel },
-        isActive && { borderColor: themeColor + '55', borderWidth: 1 },
+        isActive && { borderColor: withAlpha(themeColor, 0.33), borderWidth: 1 },
       ]}
     >
       {/* Decorative moon */}

--- a/src/screens/settings/appearance/components/GridColumns.tsx
+++ b/src/screens/settings/appearance/components/GridColumns.tsx
@@ -10,6 +10,7 @@ import { setGridColumns } from '@/utils/redux/slices/settingsSlice';
 import { spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
 import SettingsCard from '../../components/SettingsCard';
+import { withAlpha } from '@/features/theme/coverAccent';
 
 const MIN_COLUMNS = 2;
 const MAX_COLUMNS = 5;
@@ -28,7 +29,7 @@ export const GridColumns: React.FC = () => {
         <Text style={[styles.label, { color: colors.secondary }]}>
           {t('settings.appearance.gridColumns.label')}
         </Text>
-        <View style={[styles.badge, { backgroundColor: themeColor + '22', borderRadius: rad.card }]}>
+        <View style={[styles.badge, { backgroundColor: withAlpha(themeColor, 0.13), borderRadius: rad.card }]}>
           <Text style={[styles.badgeText, { color: themeColor }]}>{gridColumns}</Text>
         </View>
       </View>

--- a/src/screens/settings/appearance/components/LanguageBottomSheet.tsx
+++ b/src/screens/settings/appearance/components/LanguageBottomSheet.tsx
@@ -16,6 +16,7 @@ import { renderBackdrop } from '@/components/BottomSheetBackdrop';
 import Touchable from '@/components/Touchable';
 import { iconSize, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
+import { withAlpha } from '@/features/theme/coverAccent';
 
 interface LanguageBottomSheetProps {
   selected: string;
@@ -64,7 +65,7 @@ const LanguageBottomSheet = forwardRef<
                 styles.pickerItem,
                 {
                   backgroundColor: isSelected
-                    ? themeColor + '22'
+                    ? withAlpha(themeColor, 0.13)
                     : 'transparent',
                   borderRadius: rad.md,
                 },

--- a/src/screens/settings/player/components/Crossfade.tsx
+++ b/src/screens/settings/player/components/Crossfade.tsx
@@ -15,6 +15,7 @@ import { spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
 import SettingsCard from '../../components/SettingsCard';
 import SettingsToggleRow from '../../components/SettingsToggleRow';
+import { withAlpha } from '@/features/theme/coverAccent';
 
 /**
  * Twelve seconds, because past that the overlap stops being a transition and
@@ -43,7 +44,7 @@ export const Crossfade: React.FC = () => {
           <View
             style={[
               styles.badge,
-              { backgroundColor: themeColor + '22', borderRadius: rad.card },
+              { backgroundColor: withAlpha(themeColor, 0.13), borderRadius: rad.card },
             ]}
           >
             <Text style={[styles.badgeText, { color: themeColor }]}>

--- a/src/screens/settings/player/components/Equalizer.tsx
+++ b/src/screens/settings/player/components/Equalizer.tsx
@@ -10,6 +10,7 @@ import { setEqualizerGains } from '@/utils/redux/slices/settingsSlice';
 import { spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
 import SettingsCard from '../../components/SettingsCard';
+import { withAlpha } from '@/features/theme/coverAccent';
 import {
   EQ_FREQUENCIES,
   EQ_GAIN_LIMIT_DB,
@@ -86,7 +87,7 @@ export const Equalizer: React.FC = () => {
                 styles.preset,
                 {
                   borderRadius: rad.card,
-                  backgroundColor: selected ? themeColor : colors.border + '55',
+                  backgroundColor: selected ? themeColor : withAlpha(colors.border, 0.33),
                 },
               ]}
             >

--- a/src/utils/audio/playableFormat.test.ts
+++ b/src/utils/audio/playableFormat.test.ts
@@ -25,14 +25,16 @@ describe('formatOf', () => {
 
 describe('playableQuality', () => {
   /**
-   * The reported bug: an Ogg Vorbis album played on every quality except
-   * Original, where iOS has no decoder and the track failed outright.
+   * Vorbis used to be transcoded here. The engine vendors libvorbis now, so
+   * the file the bug was reported against stays at Original and is decoded on
+   * the device — which is the whole point of choosing Original.
    */
-  it('transcodes an Ogg on iOS rather than failing to play it', () => {
-    expect(playableQuality({ mimeType: 'audio/ogg' }, 'original', 'ios')).toBe('high');
+  it('keeps Ogg Vorbis at original, because the engine decodes it', () => {
+    expect(playableQuality({ mimeType: 'audio/ogg' }, 'original', 'ios')).toBe('original');
+    expect(playableQuality({ filePath: 'a/b.ogg' }, 'original', 'ios')).toBe('original');
   });
 
-  it('leaves Ogg alone on Android, which can decode it', () => {
+  it('leaves Ogg alone on Android too', () => {
     expect(playableQuality({ mimeType: 'audio/ogg' }, 'original', 'android')).toBe('original');
   });
 
@@ -42,9 +44,10 @@ describe('playableQuality', () => {
     }
   });
 
-  /** Opus is the other common one Core Audio cannot open. */
+  /** Opus is still undecoded here — libvorbis is not libopus. */
   it('transcodes Opus on iOS', () => {
     expect(playableQuality({ filePath: 'a/b.opus' }, 'original', 'ios')).toBe('high');
+    expect(playableQuality({ mimeType: 'audio/opus' }, 'original', 'ios')).toBe('high');
   });
 
   /**
@@ -53,7 +56,7 @@ describe('playableQuality', () => {
    */
   it('never changes a quality that already transcodes', () => {
     for (const quality of ['low', 'medium', 'high'] as const) {
-      expect(playableQuality({ mimeType: 'audio/ogg' }, quality, 'ios')).toBe(quality);
+      expect(playableQuality({ mimeType: 'audio/opus' }, quality, 'ios')).toBe(quality);
     }
   });
 

--- a/src/utils/audio/playableFormat.test.ts
+++ b/src/utils/audio/playableFormat.test.ts
@@ -1,0 +1,69 @@
+import { formatOf, playableQuality } from './playableFormat';
+
+describe('formatOf', () => {
+  it('prefers the MIME type', () => {
+    expect(formatOf({ mimeType: 'audio/ogg', filePath: '/x/y.flac' })).toBe('ogg');
+  });
+
+  it('strips parameters and the x- prefix', () => {
+    expect(formatOf({ mimeType: 'audio/x-flac; charset=binary' })).toBe('flac');
+  });
+
+  it('falls back to the file extension', () => {
+    expect(formatOf({ filePath: '/music/Tame Impala/03 - Borderline.ogg' })).toBe('ogg');
+  });
+
+  /** A path with a dot in a directory name must not be read as a format. */
+  it('ignores an implausible extension', () => {
+    expect(formatOf({ filePath: '/music/no-extension-here' })).toBeNull();
+  });
+
+  it('is null when nothing says what the file is', () => {
+    expect(formatOf({})).toBeNull();
+  });
+});
+
+describe('playableQuality', () => {
+  /**
+   * The reported bug: an Ogg Vorbis album played on every quality except
+   * Original, where iOS has no decoder and the track failed outright.
+   */
+  it('transcodes an Ogg on iOS rather than failing to play it', () => {
+    expect(playableQuality({ mimeType: 'audio/ogg' }, 'original', 'ios')).toBe('high');
+  });
+
+  it('leaves Ogg alone on Android, which can decode it', () => {
+    expect(playableQuality({ mimeType: 'audio/ogg' }, 'original', 'android')).toBe('original');
+  });
+
+  it('leaves formats iOS can decode at original', () => {
+    for (const mimeType of ['audio/flac', 'audio/mpeg', 'audio/mp4', 'audio/x-aiff']) {
+      expect(playableQuality({ mimeType }, 'original', 'ios')).toBe('original');
+    }
+  });
+
+  /** Opus is the other common one Core Audio cannot open. */
+  it('transcodes Opus on iOS', () => {
+    expect(playableQuality({ filePath: 'a/b.opus' }, 'original', 'ios')).toBe('high');
+  });
+
+  /**
+   * Only `original` asks for the raw file, so nothing else can produce this
+   * failure and nothing else should be touched.
+   */
+  it('never changes a quality that already transcodes', () => {
+    for (const quality of ['low', 'medium', 'high'] as const) {
+      expect(playableQuality({ mimeType: 'audio/ogg' }, quality, 'ios')).toBe(quality);
+    }
+  });
+
+  /**
+   * An unknown format keeps today's behaviour rather than transcoding
+   * defensively: metadata is often missing, and downgrading every track
+   * without a MIME type would quietly cost quality across a whole library to
+   * avoid a failure that may not exist.
+   */
+  it('leaves a track alone when the format is unknown', () => {
+    expect(playableQuality({}, 'original', 'ios')).toBe('original');
+  });
+});

--- a/src/utils/audio/playableFormat.ts
+++ b/src/utils/audio/playableFormat.ts
@@ -10,10 +10,19 @@ import type { AudioQuality } from '@/utils/redux/slices/settingsSlice';
  * and the failure is total rather than degraded: the reader cannot open the
  * stream, so nothing comes out.
  *
- * That is not hypothetical. An Ogg Vorbis album on a Navidrome server plays
- * on every quality except Original, where iOS's Core Audio has no Vorbis
- * decoder and the track fails with "Unable to play track" — one album
- * unplayable while the rest of the library is fine.
+ * That is not hypothetical. An Ogg Vorbis album on a Navidrome server played
+ * on every quality except Original, where Core Audio has no Vorbis decoder and
+ * the track failed with "Unable to play track" — one album unplayable while
+ * the rest of the library was fine. The engine now vendors libvorbis and
+ * decodes those itself, so Vorbis is on the decodable list and the transcode
+ * is no longer needed for it.
+ *
+ * Opus stays off the list: nothing decodes it here yet. The residual gap is
+ * Opus inside a `.ogg` rather than a `.opus`, which is unusual but legal —
+ * the extension says Vorbis, so this leaves it at Original, the engine's
+ * sniff correctly declines to treat it as Vorbis, and Core Audio cannot open
+ * it either. That file fails where it used to transcode. Narrow enough to
+ * accept knowingly rather than transcode every Vorbis library to avoid.
  */
 
 /**
@@ -37,6 +46,9 @@ const IOS_DECODABLE = [
   'wav', 'wave', 'x-wav',
   'aif', 'aiff', 'x-aiff',
   'caf',
+  // Not Core Audio's — the engine vendors libvorbis and decodes these itself,
+  // which is why a self-hosted Vorbis library can stay on Original.
+  'ogg', 'vorbis', 'oga',
 ];
 
 /** The format token from a MIME type or a filename, lowercased. */

--- a/src/utils/audio/playableFormat.ts
+++ b/src/utils/audio/playableFormat.ts
@@ -1,0 +1,73 @@
+import { Platform } from 'react-native';
+import type { AudioQuality } from '@/utils/redux/slices/settingsSlice';
+
+/**
+ * Whether the platform's decoder can open a file at all.
+ *
+ * "Original" quality asks the server for the untouched file, which is the
+ * right default — it is the only way to hear a lossless library losslessly.
+ * It is also the one setting that can produce a track the device cannot play,
+ * and the failure is total rather than degraded: the reader cannot open the
+ * stream, so nothing comes out.
+ *
+ * That is not hypothetical. An Ogg Vorbis album on a Navidrome server plays
+ * on every quality except Original, where iOS's Core Audio has no Vorbis
+ * decoder and the track fails with "Unable to play track" — one album
+ * unplayable while the rest of the library is fine.
+ */
+
+/**
+ * What iOS can decode, by container or codec.
+ *
+ * A list of what *works* rather than what does not, deliberately. An unknown
+ * format then transcodes — which costs some quality and some server CPU — and
+ * the alternative is a track that will not play. Getting this wrong in the
+ * safe direction is audible; getting it wrong in the other direction is
+ * silent.
+ *
+ * Core Audio has no Vorbis, Opus, WavPack, Musepack or APE decoder. Android
+ * is not listed because Media3 handles all of those, which is why this is
+ * platform-specific rather than a general capability list.
+ */
+const IOS_DECODABLE = [
+  'mp3', 'mpeg',
+  'aac', 'm4a', 'm4b', 'mp4',
+  'alac',
+  'flac',
+  'wav', 'wave', 'x-wav',
+  'aif', 'aiff', 'x-aiff',
+  'caf',
+];
+
+/** The format token from a MIME type or a filename, lowercased. */
+export function formatOf(song: { mimeType?: string; filePath?: string }): string | null {
+  const mime = song.mimeType?.split(';')[0]?.trim().toLowerCase();
+  if (mime) {
+    const subtype = mime.split('/')[1];
+    if (subtype) return subtype.replace(/^x-/, '');
+  }
+  const extension = song.filePath?.split('.').pop()?.toLowerCase();
+  return extension && extension.length <= 5 ? extension : null;
+}
+
+/**
+ * The quality to actually request for this track.
+ *
+ * Only ever downgrades `original`, and only when the format is known and
+ * known-undecodable. An unknown format is left alone: today's behaviour is to
+ * try the raw file, and transcoding every track whose metadata happens to be
+ * missing would be a worse trade than the failure it avoids.
+ */
+export function playableQuality(
+  song: { mimeType?: string; filePath?: string },
+  quality: AudioQuality,
+  platform: string = Platform.OS,
+): AudioQuality {
+  if (quality !== 'original') return quality;
+  if (platform !== 'ios') return quality;
+
+  const format = formatOf(song);
+  if (!format) return quality;
+
+  return IOS_DECODABLE.includes(format) ? quality : 'high';
+}


### PR DESCRIPTION
## Summary

Follow-up to #184, fixing what a real build found. Everything here came from listening to the app rather than reading it — three of the five were reported by a person, and the other two by a second session testing on Android hardware.

### The crossfade was inverted

The fade-out curve read `1 - sqrt(1 - (1 - position))`, and that inner `1 - (1 - position)` collapses to `position`. Interpolated between start and target, the outgoing gain became `sqrt(position)` — it started at **silence**, rose across the whole fade, and was cut to zero at the end.

Reported as: the song dips, the next one is instantly audible, and then the ending song gets *clearer again*. That last symptom is what identified it — nothing else makes a departing track get louder.

The existing `testCrossfadeDoesNotDipInTheMiddle` could not have caught it. It sets `outputVolume` by hand to `sqrt(0.5)` and renders, which tests that the *mixer* sums equal-power gains without dipping — true, useful, and independent of whatever curve `fade()` computes. It passed the entire time.

### And it advanced twice

During a crossfade the outgoing track keeps playing to its own natural end, seconds after the crossover already moved the queue on. The guard against double-advancing checked `transitioning`, but that is cleared *at* the crossover — so the whole second half of every fade was a window where the outgoing track could end with the guard already down, throwing the listener into a third song.

### The rest

- **Ogg Vorbis is decoded on the device.** Core Audio has no Vorbis decoder, so an `.ogg` could not be opened at all — one album showed "Unable to play track" while the rest of the library played. libogg and libvorbis are vendored (BSD-3, compatible with both licences); the app no longer transcodes around a limitation that no longer exists.
- **A cold-launch race.** The app opened, showed the track and sat paused until restarted. `setup()` is fire-and-forget, and every native transport function was `self.engine?.play()` — optional-chained, so a call arriving before the graph existed was a silent no-op. Calls now queue behind setup, and twenty-one commands raise a named error instead of vanishing.
- **CarPlay could never have worked.** The tracked `Info.plist` still named `RNTPCarPlaySceneDelegate`, a class that left with the package, and the engine's config plugin was never registered.
- **Lock-screen times disagreed** between paused and playing — the fix point is only re-sent on transitions, and the engine's position comes from rendered frames, which stop during a stall while the wall clock does not.
- **The sleep timer inherited the crossfade's curve** when the crossfade fix made the ramp equal-power. Caught by the Android session before it made the same change there.
- **An Android rendering bug**, found on device: `'#RRGGBB' + '55'` fails to *update* on Android, so the EQ preset chips never deselected. Eleven sites converted, three of which were latent instances nobody had reported.

## Type of change
- [x] Bug fix
- [x] New feature
- [x] Documentation

## Testing

```
npx tsc --noEmit    clean
npx jest --ci       873 passing, 92 suites
npm run lint        0 errors
git diff --check    clean
```

Engine: `swift test` 215 passing, plus a mutation suite (`Tools/mutate.py`) that breaks nine real behaviours and confirms a test notices each one.

**iOS:** built against the *published* engine package — `npm install` from git, `pod install`, `xcodebuild` — then installed and played a track. That distinction matters here: an earlier verification of the Vorbis work compiled a working copy rsynced into `node_modules`, and passed while `.gitignore` was silently excluding all 64 of libvorbis's source files from every commit. The published engine contained a Vorbis decoder with no decoder in it. Fixed, and re-verified the honest way.

**Android:** built and run on hardware by a second session throughout — playback, queue editing with the index rule intact across every edit, and the EQ confirmed working over real DSP.

## Known gaps

- Ogg **Opus** is written and passing 221 tests under `swift test`, but is not in this PR: the CocoaPods build needs a per-library header layout that a single `header_mappings_dir` cannot express. Parked on the engine's `opus-decoder` branch. `.opus` files continue to be transcoded by the server, which works.
- Android has no crossfade overlap yet — tracks advance but do not fade. In progress.
- `clearCache`/`cacheStats` are still unimplemented on Android and reachable from Settings.
