### PR TITLE
Fix the 2.1.0 release install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yuzic",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yuzic",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@backpackapp-io/react-native-toast": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e:onboarding": "maestro test .maestro/onboarding-demo.yaml",
     "test:e2e:details": "maestro test .maestro/detail-flows.yaml",
     "lint": "expo lint",
-    "postinstall": "patch-package"
+    "postinstall": "if [ -e node_modules/.bin/patch-package ]; then patch-package --error-on-fail; fi"
   },
   "overrides": {
     "lucide-react-native": {


### PR DESCRIPTION
`npm ci --omit=dev` made postinstall fail with exit 127 — `patch-package` is a devDependency and npm still runs the script. Both halves of the 2.1.0 release died at the install step before any build started.

Guarded on the binary, so a development install still runs it and a real patch failure still fails. Verified both ways locally: `npm ci --omit=dev` completes with patch-package and expo-dev-client absent, and a plain `npm install` has both.

Version stays 2.1.0, so this merge will not re-fire `release-on-version-bump` — the builds get dispatched manually after it lands.