### PR TITLE
Take the engine's seek fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "github:yuzicapp/yuzic-engine#1af5d4be3b887078eead6ee3e4ea428dbc0d308a"
+        "yuzic-engine": "github:yuzicapp/yuzic-engine#9be134a00c63c39c6332d015a61dc831f65c3a8d"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17954,9 +17954,9 @@
       }
     },
     "node_modules/yuzic-engine": {
-      "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/yuzicapp/yuzic-engine.git#1af5d4be3b887078eead6ee3e4ea428dbc0d308a",
-      "integrity": "sha512-cT+hEaozzlSskBBB71Y24L7N3SJAyUowt4PtW33a1nNqcb0bZJkl/Y++wIzglqmaYhOmQpOVsBCsN132KVHbpw==",
+      "version": "1.0.1",
+      "resolved": "git+ssh://git@github.com/yuzicapp/yuzic-engine.git#9be134a00c63c39c6332d015a61dc831f65c3a8d",
+      "integrity": "sha512-vdreued7fhBanBPoliQPaMmn5B70Kplf7w2vGmZzgqPr7Am3UpJM8JevJBvEpT8KllhSyysOL90MAh1rAADZEg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "github:yuzicapp/yuzic-engine#1af5d4be3b887078eead6ee3e4ea428dbc0d308a"
+    "yuzic-engine": "github:yuzicapp/yuzic-engine#9be134a00c63c39c6332d015a61dc831f65c3a8d"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Bumps `yuzic-engine` to [1.0.1](https://github.com/yuzicapp/yuzic-engine/releases/tag/v1.0.1).

### What this fixes

Seeking near the end of a streamed track played **nothing**, and a second seek skipped to the next song. Reported against "Life Is Good"; the same track **downloaded was fine**, which is what made it findable — a local file never takes the streaming path.

`StreamingByteSource.cancel()` called `producer.stop()`, which for the HTTP producer cancels the `URLSessionDataTask` *and invalidates the session* — irreversible. `resume()` only cleared a boolean, and `startIfNeeded()` sits behind a `started` guard that never resets, so nothing ever restarted the stream.

Every seek runs `cancelPendingReads()` → `resumePendingReads()` over the same source. That is correct for the ranged transport, where a cancelled range request is simply reissued at the new offset, and fatal for the single-producer transcoded stream: the first seek ended the transcode for good, and every read afterwards waited out the 12-second timeout and threw.

The fix is in the engine, not here. `cancel()`'s contract on `ByteSource` is exactly "unblocks any waiting read" — stopping the producer was always more than it was asked to do, and teardown already belongs to `deinit`. Letting the download continue through a seek is better regardless: the buffer keeps filling while the reader is repositioned, so a backward seek lands in bytes already held.

A second fix rides along: an empty read at an **estimated** length is no longer treated as a clean end-of-file. For a sequential source that length is `duration × bitrate` until the stream ends, and the engine advances the queue on an end-of-file — so an undershooting estimate made tracks end themselves. A new `isFinished` on `ByteSource` distinguishes a known length from a guess.

**Android is structurally unaffected.** Media3 owns that transport: no `cancel`/`resume` pair, no producer to stop, and no length estimate — it reports `TIME_UNSET` rather than guessing.

### Verification

- Engine suite **283/283**, up from 278 — three of those were iOS mutual-TLS tests that had *never* passed on a Mac (`SecPKCS12Import` needs an explicit keychain there; it returns `-26276` for any PKCS#12 without one).
- RED/GREEN proven both ways: against the old `cancel()` the new regression test fails with `stream did not reach 100 within 0.25s (have 0)` — the device's silence, with a shorter timeout.
- The existing `FakeProducer` kept delivering after `stop()`, which is why the suite never saw this; the new tests use a producer that actually stops.
- Engine CI green across TypeScript, parity, `swift test`, and Android.
- Here: lint clean, `tsc` clean, **902/902** tests.

Not yet verified on a handset against a real mutual-TLS server — worth a listen to "Life Is Good" after this lands.