### PR TITLE
Install the engine from npm rather than from a commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "github:yuzicapp/yuzic-engine#9be134a00c63c39c6332d015a61dc831f65c3a8d"
+        "yuzic-engine": "^1.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17955,8 +17955,8 @@
     },
     "node_modules/yuzic-engine": {
       "version": "1.0.1",
-      "resolved": "git+ssh://git@github.com/yuzicapp/yuzic-engine.git#9be134a00c63c39c6332d015a61dc831f65c3a8d",
-      "integrity": "sha512-vdreued7fhBanBPoliQPaMmn5B70Kplf7w2vGmZzgqPr7Am3UpJM8JevJBvEpT8KllhSyysOL90MAh1rAADZEg==",
+      "resolved": "https://registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.1.tgz",
+      "integrity": "sha512-54UdhmmfHfWyDqnBR75Zhh+zSGdd0lt6euNWIxpt1zIB8Hd0JIaz3v06UAlmQI6unZ0FIoWi2HO6Tl0yWJn17w==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "github:yuzicapp/yuzic-engine#9be134a00c63c39c6332d015a61dc831f65c3a8d"
+    "yuzic-engine": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
[`yuzic-engine` is on npm](https://www.npmjs.com/package/yuzic-engine) now, so this swaps the git SHA for a version range.

```diff
-"yuzic-engine": "github:yuzicapp/yuzic-engine#9be134a..."
+"yuzic-engine": "^1.0.1"
```

### Why

The git pin is the thing this repo has been caught by twice, and `AGENTS.md` says so outright: bumping it once and then making further engine commits leaves the app building an engine older than the one you are reading. A version range cannot drift that way, and the lockfile still records exactly which tarball a build used — `registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.1.tgz` rather than a commit that may or may not be an ancestor of anything.

A caret range also means a patch release is picked up by an ordinary `npm install`, which is the behaviour that makes a published engine worth having.

### Verified

- Resolution confirmed to come from the registry, not git.
- Installed version 1.0.1; podspec, `expo-module.config.json` and `android/build.gradle` all present in `node_modules`, so Expo autolinking and both native builds still find the module.
- `tsc` clean, lint clean (0 errors), **902/902** tests.
- A clean-room `npm install yuzic-engine` in an empty project was checked against the source tree: 64 files under `ios/Vendor/vorbis/lib` on both sides, all 22 `.c` sources present — the decoder that once silently shipped empty is intact.

Native builds are not exercised by CI here, so the first iOS/Android build off this branch is the real confirmation that autolinking resolves a registry install the same way it resolved a git one.