### PR TITLE
Let the app stay usable when the server can't be reached

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,6 +247,39 @@ dispatch it into a slice like the others. If it's per-server, key by
 payload), gate the fetch behind a stale-time check via `queryClient.fetchQuery`
 so a re-sync inside the 30-min window returns the cached value.
 
+## 5. Reachability — offline, and the server being gone
+
+Two different signals, and using the wrong one is the recurring bug:
+
+- **`useIsOffline`** — the device has no network (NetInfo).
+- **`useServerUnreachable`** — the device is online but the *music server* is
+  not: Tailscale down, server rebooting, DNS moved. NetInfo reports online, so
+  nothing offline-related engages on its own and every request instead hangs to
+  its own timeout. `ServerReachabilityWatcher` pings while the flag is set and
+  clears it on the first success.
+
+`useServerReachable()` in `features/connectivity` is the two of them together,
+and is what a surface should ask when the question is "can I call the server".
+
+Three shapes of consumer:
+
+1. **Has a synced fallback** (albums, artists, playlists, tracks, starred) —
+   `useOfflineFirstQuery`. It folds both signals in, serves library data when
+   the server can't be asked, and returns `degraded` so the screen can say the
+   data is local rather than fresh.
+2. **Has a local equivalent but isn't a query** — search. See
+   `contexts/searchLegs.ts`: the legs are decided before any fetch, and a
+   *server* scope falls back to the local index rather than to nothing.
+3. **Has no local equivalent** (radio, podcasts, shares, the server-backed Home
+   shelves) — gate `enabled` on `useServerReachable()` and render an offline
+   empty state. These have nothing to degrade *to*, so the honest answer is to
+   say so rather than spin into a load failure.
+
+**A skipped leg is not a failed leg.** Anything that reports both needs two
+flags: attempting a request that cannot land, catching the timeout, and calling
+it an error is how offline search came to show a red banner over results that
+had actually succeeded.
+
 ## Where things live
 
 ```

--- a/src/app/(home)/(tabs)/(library)/index.tsx
+++ b/src/app/(home)/(tabs)/(library)/index.tsx
@@ -8,10 +8,14 @@ import { useScrollToTop } from '@react-navigation/native'
 import { useTheme } from '@/hooks/useTheme'
 import { useAccountSheet } from '@/contexts/AccountSheetContext'
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors'
+import { useServerReachable } from '@/features/connectivity/useServerReachable'
 
 import TabHeader from '@/components/TabHeader'
+import StatusBanner from '@/components/StatusBanner'
 import LibraryEntryRows from '@/screens/library/LibraryEntryRows'
 import { useScrollClearance } from '@/hooks/useScrollClearance'
+import { iconSize, spacing } from '@/constants/design'
+import { CloudOff } from 'lucide-react-native'
 
 /**
  * The library index: one entry point per way of browsing the collection.
@@ -32,6 +36,7 @@ export default function LibraryScreen() {
   const activeServer = useSelector(selectActiveServer)
   const username = activeServer?.username
   const { openAccountSheet } = useAccountSheet()
+  const serverReachable = useServerReachable()
 
   const scrollRef = useRef<ScrollView>(null)
   useScrollToTop(scrollRef)
@@ -53,6 +58,14 @@ export default function LibraryScreen() {
         contentContainerStyle={{ paddingBottom: scrollClearance }}
         showsVerticalScrollIndicator={false}
       >
+        {!serverReachable && (
+          <StatusBanner
+            icon={<CloudOff size={iconSize.badge} color={colors.subtext} />}
+            text={t('library.offlineBanner')}
+            style={styles.offlineBanner}
+            testID="library-offline-banner"
+          />
+        )}
         <LibraryEntryRows />
       </ScrollView>
     </SafeAreaView>
@@ -61,4 +74,8 @@ export default function LibraryScreen() {
 
 const styles = StyleSheet.create({
   screen: { flex: 1 },
+  offlineBanner: {
+    marginHorizontal: spacing.page,
+    marginBottom: spacing.sm,
+  },
 })

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -19,6 +19,8 @@ import * as deezer from '@/api/deezer';
 import { useAlbums } from '@/hooks/albums';
 import { useArtists } from '@/hooks/artists';
 import { usePlaylists } from '@/hooks/playlists';
+import { useIsOffline } from '@/hooks/useIsOffline';
+import { useServerUnreachable } from '@/features/connectivity/serverReachability';
 
 import { useTracks } from '@/hooks/tracks';
 import { useApi } from '@/api';
@@ -33,6 +35,7 @@ import {
 } from '@/utils/downloads/collectionState';
 
 import { dedupeAndSort, type SearchResult } from './searchRanking';
+import { planSearchLegs } from './searchLegs';
 
 export type { SearchResult } from './searchRanking';
 
@@ -49,6 +52,12 @@ interface SearchContextType {
   isLoading: boolean;
   /** True when the most recent search failed to reach the server/external source, so results shown (if any) may be incomplete. */
   hasError: boolean;
+  /**
+   * True when the remote legs of the search were deliberately skipped because
+   * the server can't be reached, so what's shown is the local library only.
+   * Distinct from `hasError`: nothing failed, it was never attempted.
+   */
+  degraded: boolean;
   handleSearchWithFilters: (query: string, filters: SearchFilters) => Promise<void>;
 }
 
@@ -164,6 +173,17 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
 
   const searchScope = useSelector(selectSearchScope);
 
+  // Whether the remote halves of a search can be attempted at all. Offline is
+  // the device having no network; serverUnreachable is the device being online
+  // while the music server isn't (VPN down, server rebooting) — the case that
+  // otherwise leaves every keystroke hanging until its own timeout.
+  const isOffline = useIsOffline();
+  const serverUnreachable = useServerUnreachable();
+  const canReachServer = !isOffline && !serverUnreachable;
+  // Deezer is a public API, so it only needs the device to be online — an
+  // unreachable *music server* says nothing about whether Deezer is up.
+  const canReachExternal = !isOffline;
+
   const {
     downloadedTracks,
     getAllDownloadedCollections,
@@ -199,6 +219,7 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     useState<SearchResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hasError, setHasError] = useState(false);
+  const [degraded, setDegraded] = useState(false);
 
   const searchRequestIdRef = useRef(0);
 
@@ -291,6 +312,7 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     setSearchResults([]);
     setIsLoading(false);
     setHasError(false);
+    setDegraded(false);
   }, []);
 
   const handleSearchWithFilters = useCallback(async (query: string, filters: SearchFilters) => {
@@ -299,6 +321,7 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
       setSearchResults([]);
       setIsLoading(false);
       setHasError(false);
+      setDegraded(false);
       return;
     }
     setIsLoading(true);
@@ -307,28 +330,47 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
       const lowerQuery = query.toLowerCase();
       const results: SearchResult[] = [];
 
-      if (filters.local) {
-        if (searchScope.includes('client')) {
-          results.push(...await searchLibrary(query));
-        }
-        if (requestId !== searchRequestIdRef.current) return;
-        if (searchScope.includes('server')) {
-          try { results.push(...await searchServer(query)); } catch { errored = true; }
-        }
-        if (requestId !== searchRequestIdRef.current) return;
-      }
+      // Decide the legs up front rather than at each call site. A leg that
+      // cannot land is not attempted at all: each one would otherwise hang to
+      // its own timeout on every keystroke and then land in the same `catch`
+      // as a real failure, so local results that succeeded were shown
+      // underneath an error banner.
+      const legs = planSearchLegs({
+        filters,
+        searchScope,
+        serverReachable: canReachServer,
+        deviceOnline: canReachExternal,
+      });
 
-      if (filters.deezer) {
+      if (legs.client) {
+        results.push(...await searchLibrary(query));
+      }
+      if (requestId !== searchRequestIdRef.current) return;
+
+      if (legs.server) {
+        try { results.push(...await searchServer(query)); } catch { errored = true; }
+      }
+      if (requestId !== searchRequestIdRef.current) return;
+
+      if (legs.external) {
         try { results.push(...await searchExternal(query)); } catch { errored = true; }
       }
       if (requestId !== searchRequestIdRef.current) return;
 
       setSearchResults(dedupeAndSort(results, lowerQuery));
       setHasError(errored);
+      setDegraded(legs.degraded);
     } finally {
       if (requestId === searchRequestIdRef.current) setIsLoading(false);
     }
-  }, [searchExternal, searchLibrary, searchScope, searchServer]);
+  }, [
+    canReachExternal,
+    canReachServer,
+    searchExternal,
+    searchLibrary,
+    searchScope,
+    searchServer,
+  ]);
 
   const value = useMemo<SearchContextType>(() => ({
     searchResults,
@@ -337,6 +379,7 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     clearSearch,
     isLoading,
     hasError,
+    degraded,
     handleSearchWithFilters,
   }), [
     searchResults,
@@ -345,6 +388,7 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     clearSearch,
     isLoading,
     hasError,
+    degraded,
     handleSearchWithFilters,
   ]);
 

--- a/src/contexts/searchLegs.test.ts
+++ b/src/contexts/searchLegs.test.ts
@@ -1,0 +1,86 @@
+import { planSearchLegs } from './searchLegs';
+
+const BOTH_FILTERS = { local: true, deezer: true };
+
+describe('planSearchLegs', () => {
+  it('attempts every leg the scope asks for when everything is reachable', () => {
+    expect(planSearchLegs({
+      filters: BOTH_FILTERS,
+      searchScope: 'server',
+      serverReachable: true,
+      deviceOnline: true,
+    })).toEqual({ client: false, server: true, external: true, degraded: false });
+  });
+
+  it('searches the local index when that is the chosen scope', () => {
+    const plan = planSearchLegs({
+      filters: { local: true, deezer: false },
+      searchScope: 'client',
+      serverReachable: true,
+      deviceOnline: true,
+    });
+    expect(plan).toEqual({ client: true, server: false, external: false, degraded: false });
+  });
+
+  // The regression this file exists for: offline, the server leg was still
+  // attempted, hung to its timeout on every keystroke, and then landed in the
+  // same catch as a real failure — so results that had succeeded locally were
+  // shown under an error banner.
+  it('reports a skipped leg as degraded rather than failed', () => {
+    expect(planSearchLegs({
+      filters: BOTH_FILTERS,
+      searchScope: 'server',
+      serverReachable: false,
+      deviceOnline: true,
+    }).degraded).toBe(true);
+  });
+
+  // The default scope is 'server'. Without this fallback an offline search
+  // over a fully synced library returns nothing at all, which is what it did.
+  it('falls back to the local index when the server scope cannot be reached', () => {
+    const plan = planSearchLegs({
+      filters: { local: true, deezer: false },
+      searchScope: 'server',
+      serverReachable: false,
+      deviceOnline: false,
+    });
+    expect(plan.client).toBe(true);
+    expect(plan.server).toBe(false);
+    expect(plan.degraded).toBe(true);
+  });
+
+  it('still asks Deezer when only the music server is unreachable', () => {
+    // A downed VPN takes the server away while the internet is fine. Folding
+    // both into one flag would drop external results in that exact case.
+    const plan = planSearchLegs({
+      filters: BOTH_FILTERS,
+      searchScope: 'server',
+      serverReachable: false,
+      deviceOnline: true,
+    });
+    expect(plan.server).toBe(false);
+    expect(plan.external).toBe(true);
+  });
+
+  it('is not degraded when the only unreachable leg was never asked for', () => {
+    expect(planSearchLegs({
+      filters: { local: true, deezer: false },
+      searchScope: 'client',
+      serverReachable: false,
+      deviceOnline: false,
+    })).toEqual({ client: true, server: false, external: false, degraded: false });
+  });
+
+  it('drops the local legs entirely when the local filter is off', () => {
+    const plan = planSearchLegs({
+      filters: { local: false, deezer: true },
+      searchScope: 'server',
+      serverReachable: false,
+      deviceOnline: true,
+    });
+    expect(plan.client).toBe(false);
+    expect(plan.server).toBe(false);
+    expect(plan.external).toBe(true);
+    expect(plan.degraded).toBe(false);
+  });
+});

--- a/src/contexts/searchLegs.ts
+++ b/src/contexts/searchLegs.ts
@@ -1,0 +1,72 @@
+export type SearchScope = 'client' | 'server';
+
+/**
+ * Which legs of a search are worth attempting.
+ *
+ * Extracted from `SearchContext` because the interesting part is a decision,
+ * not a fetch: a leg that cannot land should not be *attempted*, and a leg that
+ * was deliberately skipped is not a leg that *failed*. Getting the second half
+ * wrong is what made offline search read as broken — the local results arrived
+ * fine and were then shown underneath an error banner, because the skipped
+ * server call had fallen into the same `catch` as a real failure.
+ *
+ * The two reachability inputs are deliberately separate. `serverReachable` is
+ * about the user's own music server (which a downed VPN takes away while the
+ * device stays online); `deviceOnline` is about the internet at large. Deezer
+ * needs only the second — an unreachable Navidrome says nothing about whether
+ * Deezer is up — so folding them into one flag would silently drop external
+ * results in the most common failure case.
+ *
+ * **Scope is one or the other, not a set.** `searchScope` is a single value and
+ * the old code tested it with `String.prototype.includes`, which reads like an
+ * array check and is not one. It happened to be correct, but it hid the
+ * consequence: the default scope is `'server'`, so with the server unreachable
+ * there was no local leg to fall back to and an offline search returned nothing
+ * at all. Hence `client` below is *not* simply `scope === 'client'` — a server
+ * scope degrades to the local index rather than to an empty screen, which is
+ * the whole point of having a synced library.
+ */
+
+export type SearchLegPlan = {
+  /** Search the locally synced library index. */
+  client: boolean;
+  /** Ask the music server. */
+  server: boolean;
+  /** Ask Deezer. */
+  external: boolean;
+  /**
+   * A leg the filters asked for was skipped because it couldn't be reached, so
+   * the results are narrower than requested through no fault of the query.
+   */
+  degraded: boolean;
+};
+
+export function planSearchLegs({
+  filters,
+  searchScope,
+  serverReachable,
+  deviceOnline,
+}: {
+  filters: { local: boolean; deezer: boolean };
+  searchScope: SearchScope;
+  serverReachable: boolean;
+  deviceOnline: boolean;
+}): SearchLegPlan {
+  const wantsServer = filters.local && searchScope === 'server';
+  const wantsExternal = filters.deezer;
+
+  const server = wantsServer && serverReachable;
+  const external = wantsExternal && deviceOnline;
+
+  // The local index when it was asked for, and also whenever the server leg
+  // was wanted but can't run — otherwise the default scope means an offline
+  // search over a fully synced library shows nothing.
+  const client = filters.local && (searchScope === 'client' || (wantsServer && !server));
+
+  return {
+    client,
+    server,
+    external,
+    degraded: (wantsServer && !server) || (wantsExternal && !external),
+  };
+}

--- a/src/features/connectivity/useServerReachable.ts
+++ b/src/features/connectivity/useServerReachable.ts
@@ -1,0 +1,22 @@
+import { useIsOffline } from '@/hooks/useIsOffline';
+import { useServerUnreachable } from './serverReachability';
+
+/**
+ * Whether the active music server can be asked for anything right now.
+ *
+ * Two conditions, both of which mean "don't issue the request", for different
+ * reasons: the device has no network at all, or the device is online while the
+ * server isn't (VPN down, server rebooting, DNS moved). The second is the one
+ * worth having a signal for — NetInfo reports online, so nothing else engages,
+ * and each request instead hangs until its own timeout.
+ *
+ * `useOfflineFirstQuery` folds this in already for the resources that have a
+ * synced fallback. This hook is for the ones that have none — radio, podcasts,
+ * shares — where the honest answer offline is an empty state saying so, rather
+ * than a spinner that resolves into a load failure.
+ */
+export function useServerReachable(): boolean {
+  const isOffline = useIsOffline();
+  const serverUnreachable = useServerUnreachable();
+  return !isOffline && !serverUnreachable;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -495,7 +495,8 @@
       "noConnection": "No internet connection",
       "syncedChanges": "Offline changes synced",
       "syncQueuedChangesFailed": "Some offline changes could not sync",
-      "notAvailable": "Not available offline"
+      "notAvailable": "Not available offline",
+      "serverOnlyFeature": "Not available offline — this lives on your server"
     },
     "oneSecond": "One moment.",
     "playingSimilar": "Playing similar music",
@@ -581,6 +582,7 @@
     }
   },
   "library": {
+    "offlineBanner": "Offline — showing your synced library and downloads",
     "title": "Library",
     "view": {
       "switchToList": "Switch to list view",
@@ -688,6 +690,7 @@
     "placeholder": "Search for music, artists, or playlists...",
     "noResults": "No results found",
     "searchError": "Couldn't reach the server — results may be incomplete",
+    "searchLocalOnly": "Showing your library only — can't reach the server",
     "recentSearches": "Recent searches",
     "clearRecent": "Clear",
     "removeRecentSearch": "Remove \"{{query}}\" from recent searches",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -493,7 +493,8 @@
       "noConnection": "Pas de connexion internet",
       "syncedChanges": "Modifications hors ligne synchronisées",
       "syncQueuedChangesFailed": "Certaines modifications hors ligne n'ont pas pu être synchronisées",
-      "notAvailable": "Indisponible hors ligne"
+      "notAvailable": "Indisponible hors ligne",
+      "serverOnlyFeature": "Indisponible hors ligne — ce contenu est sur votre serveur"
     },
     "oneSecond": "Un instant.",
     "playingSimilar": "Lecture de musique similaire",
@@ -581,6 +582,7 @@
     }
   },
   "library": {
+    "offlineBanner": "Hors ligne — affichage de votre bibliothèque synchronisée et de vos téléchargements",
     "title": "Bibliothèque",
     "view": {
       "switchToList": "Passer à la vue liste",
@@ -688,6 +690,7 @@
     "placeholder": "Rechercher de la musique, des artistes ou des listes de lecture...",
     "noResults": "Aucun résultat trouvé",
     "searchError": "Impossible de joindre le serveur — les résultats peuvent être incomplets",
+    "searchLocalOnly": "Affichage de votre bibliothèque uniquement — serveur injoignable",
     "recentSearches": "Recherches récentes",
     "clearRecent": "Effacer",
     "removeRecentSearch": "Supprimer « {{query}} » des recherches récentes",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -492,7 +492,8 @@
       "noConnection": "インターネット接続なし",
       "syncedChanges": "オフラインの変更を同期しました",
       "syncQueuedChangesFailed": "一部のオフライン変更を同期できませんでした",
-      "notAvailable": "オフラインでは利用できません"
+      "notAvailable": "オフラインでは利用できません",
+      "serverOnlyFeature": "オフラインでは利用できません — これはサーバー上にあります"
     },
     "oneSecond": "少々お待ちください。",
     "playingSimilar": "類似の音楽を再生中",
@@ -580,6 +581,7 @@
     }
   },
   "library": {
+    "offlineBanner": "オフライン — 同期済みのライブラリとダウンロードを表示しています",
     "title": "ライブラリ",
     "view": {
       "switchToList": "リスト表示に切り替え",
@@ -685,6 +687,7 @@
     "placeholder": "音楽、アーティスト、プレイリストを検索...",
     "noResults": "結果が見つかりません",
     "searchError": "サーバーに接続できませんでした — 結果が不完全な場合があります",
+    "searchLocalOnly": "サーバーに接続できないため、ライブラリのみを表示しています",
     "recentSearches": "最近の検索",
     "clearRecent": "クリア",
     "removeRecentSearch": "「{{query}}」を最近の検索から削除",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -492,7 +492,8 @@
       "noConnection": "无网络连接",
       "syncedChanges": "离线更改已同步",
       "syncQueuedChangesFailed": "部分离线更改无法同步",
-      "notAvailable": "离线时不可用"
+      "notAvailable": "离线时不可用",
+      "serverOnlyFeature": "离线时不可用 — 此内容存储在您的服务器上"
     },
     "oneSecond": "稍等片刻。",
     "playingSimilar": "正在播放相似音乐",
@@ -580,6 +581,7 @@
     }
   },
   "library": {
+    "offlineBanner": "离线 — 显示已同步的音乐库和下载内容",
     "title": "媒体库",
     "view": {
       "switchToList": "切换到列表视图",
@@ -685,6 +687,7 @@
     "placeholder": "搜索音乐、歌手或播放列表...",
     "noResults": "未找到结果",
     "searchError": "无法连接服务器 — 结果可能不完整",
+    "searchLocalOnly": "无法连接服务器 — 仅显示您的音乐库",
     "recentSearches": "最近搜索",
     "clearRecent": "清除",
     "removeRecentSearch": "从最近搜索中删除“{{query}}”",

--- a/src/screens/home/components/ServerNowPlayingSection.tsx
+++ b/src/screens/home/components/ServerNowPlayingSection.tsx
@@ -9,6 +9,7 @@ import { useSelector } from 'react-redux';
 import { useApi } from '@/api';
 import { useTheme } from '@/hooks/useTheme';
 import { QueryKeys } from '@/enums/queryKeys';
+import { useServerReachable } from '@/features/connectivity/useServerReachable';
 import { selectServerNowPlayingShelfEnabled } from '@/utils/redux/selectors/settingsSelectors';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import MediaListRow from '@/components/MediaListRow';
@@ -50,7 +51,11 @@ export default function ServerNowPlayingSection({ sectionKey }: Props) {
   const activeServer = useSelector(selectActiveServer);
   const ownUsername = activeServer?.username?.trim().toLowerCase() ?? null;
 
-  const enabled = Boolean(api.discovery) && shelfEnabled;
+  // Also gated on the server actually being reachable: this shelf polls every
+  // 90s, so an unreachable server means a request hanging to its own timeout
+  // on repeat, forever, behind a shelf that can never render.
+  const serverReachable = useServerReachable();
+  const enabled = Boolean(api.discovery) && shelfEnabled && serverReachable;
 
   const query = useQuery<NowPlayingEntry[]>({
     queryKey: [QueryKeys.ServerNowPlaying],

--- a/src/screens/home/components/ServerRandomSection.tsx
+++ b/src/screens/home/components/ServerRandomSection.tsx
@@ -10,6 +10,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useRadius } from '@/hooks/useRadius';
 import { usePlayingActions } from '@/contexts/PlayingContext';
 import { QueryKeys } from '@/enums/queryKeys';
+import { useServerReachable } from '@/features/connectivity/useServerReachable';
 import { getDayKey, getDailySeed, seededShuffle } from '@/features/home/hooks/useDailyLayout';
 import { presentableGenres } from '@/features/home/genres';
 import { onePerAlbum } from '@/features/home/randomDraw';
@@ -56,6 +57,11 @@ export default function ServerRandomSection({ sectionKey, refreshKey = 0 }: Prop
   const { colors } = useTheme();
   const rad = useRadius();
   const api = useApi();
+  // The shelf is server-backed, so it needs the server to be reachable, not
+  // merely supported. Offline (or with the server unreachable) it hides
+  // instead of holding a skeleton over a request that cannot land.
+  const serverReachable = useServerReachable();
+  const discoveryAvailable = Boolean(api.discovery) && serverReachable;
   const { playSongs } = usePlayingActions();
   const { width: screenWidth } = useWindowDimensions();
   const genres = useSelector(selectLibraryGenres);
@@ -100,16 +106,16 @@ export default function ServerRandomSection({ sectionKey, refreshKey = 0 }: Prop
       // heading drops the genre so it still describes what is under it.
       return { songs: await draw(), themed: false };
     },
-    enabled: Boolean(api.discovery),
+    enabled: discoveryAvailable,
     staleTime: 1000 * 60 * 60 * 4,
   });
 
   const data = query.data?.songs ?? [];
-  const isLoading = Boolean(api.discovery) && query.isLoading;
+  const isLoading = discoveryAvailable && query.isLoading;
   const hasEnough = data.length >= MIN_ITEMS;
   const isThemed = Boolean(themeGenre) && (query.data?.themed ?? false);
 
-  useSourceSectionPresence(sectionKey, Boolean(api.discovery) && (isLoading || hasEnough));
+  useSourceSectionPresence(sectionKey, discoveryAvailable && (isLoading || hasEnough));
 
   const handlePlay = useCallback((index: number) => {
     if (data.length === 0) return;

--- a/src/screens/podcasts/PodcastsScreen.tsx
+++ b/src/screens/podcasts/PodcastsScreen.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigation } from '@react-navigation/native';
 import { toast } from '@backpackapp-io/react-native-toast';
-import { AlertTriangle, Plus, Podcast as PodcastIcon, RefreshCw, Trash2 } from 'lucide-react-native';
+import { AlertTriangle, CloudOff, Plus, Podcast as PodcastIcon, RefreshCw, Trash2 } from 'lucide-react-native';
 
 import { useApi } from '@/api';
 import type { PodcastChannel } from '@/api/types';
@@ -26,6 +26,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useScrollClearance } from '@/hooks/useScrollClearance';
 import { hitSlopFor, iconSize, spacing, statusColor } from '@/constants/design';
 import { QueryKeys } from '@/enums/queryKeys';
+import { useServerReachable } from '@/features/connectivity/useServerReachable';
 import type { CoverSource } from '@/types';
 
 export default function PodcastsScreen() {
@@ -34,6 +35,7 @@ export default function PodcastsScreen() {
   const api = useApi();
   const navigation = useNavigation<any>();
   const queryClient = useQueryClient();
+  const serverReachable = useServerReachable();
   const scrollClearance = useScrollClearance();
   const [adding, setAdding] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
@@ -41,7 +43,7 @@ export default function PodcastsScreen() {
   const channelsQuery = useQuery<PodcastChannel[]>({
     queryKey: [QueryKeys.Podcasts],
     queryFn: async () => (await api.podcasts?.list(false)) ?? [],
-    enabled: Boolean(api.podcasts),
+    enabled: Boolean(api.podcasts) && serverReachable,
     staleTime: 1000 * 60 * 15,
   });
 
@@ -171,7 +173,12 @@ export default function PodcastsScreen() {
         }
       />
 
-      {channelsQuery.isLoading ? (
+      {!serverReachable && !(channelsQuery.data ?? []).length ? (
+        <EmptyState
+          icon={<CloudOff size={iconSize.emptyState} color={colors.subtext} />}
+          message={t('common.offline.serverOnlyFeature')}
+        />
+      ) : channelsQuery.isLoading ? (
         <View style={styles.listContent}>
           {[...Array(8)].map((_, i) => <SkeletonListRow key={i} />)}
         </View>

--- a/src/screens/radio/RadioScreen.tsx
+++ b/src/screens/radio/RadioScreen.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@backpackapp-io/react-native-toast';
-import { Pencil, Plus, Radio as RadioIcon, Trash2 } from 'lucide-react-native';
+import { CloudOff, Pencil, Plus, Radio as RadioIcon, Trash2 } from 'lucide-react-native';
 
 import { useApi } from '@/api';
 import type { InternetRadioStation } from '@/api/types';
@@ -16,6 +16,7 @@ import EmptyState from '@/components/EmptyState';
 import SkeletonListRow from '@/components/SkeletonListRow';
 import { controlSize, hitSlopFor, iconSize, spacing } from '@/constants/design';
 import { QueryKeys } from '@/enums/queryKeys';
+import { useServerReachable } from '@/features/connectivity/useServerReachable';
 import { useRadius } from '@/hooks/useRadius';
 import { useScrollClearance } from '@/hooks/useScrollClearance';
 import { useTheme } from '@/hooks/useTheme';
@@ -37,6 +38,7 @@ export default function RadioScreen() {
   const { colors } = useTheme();
   const api = useApi();
   const queryClient = useQueryClient();
+  const serverReachable = useServerReachable();
   const scrollClearance = useScrollClearance();
   const { playSong } = usePlayingActions();
   const [editing, setEditing] = useState<Editing | null>(null);
@@ -44,7 +46,7 @@ export default function RadioScreen() {
   const stationsQuery = useQuery({
     queryKey: [QueryKeys.Radio],
     queryFn: async () => (await api.radio?.list()) ?? [],
-    enabled: Boolean(api.radio),
+    enabled: Boolean(api.radio) && serverReachable,
     staleTime: 1000 * 60 * 5,
   });
 
@@ -148,7 +150,12 @@ export default function RadioScreen() {
         }
       />
 
-      {stationsQuery.isLoading ? (
+      {!serverReachable && !stationsQuery.data?.length ? (
+        <EmptyState
+          icon={<CloudOff size={iconSize.emptyState} color={colors.subtext} />}
+          message={t('common.offline.serverOnlyFeature')}
+        />
+      ) : stationsQuery.isLoading ? (
         <View style={styles.listContent}>
           {[...Array(8)].map((_, i) => (
             <SkeletonListRow key={i} artSize={controlSize.compactMediaRowArt} />

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -77,7 +77,7 @@ const Search = () => {
 
   const [query, setQuery] = useState('');
   const [hasSearched, setHasSearched] = useState(false);
-  const { searchResults, handleSearchWithFilters, clearSearch, isLoading, hasError } = useSearch();
+  const { searchResults, handleSearchWithFilters, clearSearch, isLoading, hasError, degraded } = useSearch();
 
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -417,10 +417,10 @@ const Search = () => {
         </View>
       </View>
 
-      {hasSearched && !isLoading && hasError && (
+      {hasSearched && !isLoading && (hasError || degraded) && (
         <StatusBanner
           icon={<CloudOff size={iconSize.badge} color={colors.subtext} />}
-          text={t('search.searchError')}
+          text={hasError ? t('search.searchError') : t('search.searchLocalOnly')}
           closable
           style={styles.errorBanner}
           testID="search-error-banner"

--- a/src/screens/shares/SharesScreen.tsx
+++ b/src/screens/shares/SharesScreen.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@backpackapp-io/react-native-toast';
-import { Link2, Share2, Trash2 } from 'lucide-react-native';
+import { CloudOff, Link2, Share2, Trash2 } from 'lucide-react-native';
 
 import { useApi } from '@/api';
 import type { Share } from '@/api/types';
@@ -17,6 +17,7 @@ import { useScrollClearance } from '@/hooks/useScrollClearance';
 import { useListDensity } from '@/hooks/useListDensity';
 import { hitSlopFor, iconSize, spacing, typography } from '@/constants/design';
 import { QueryKeys } from '@/enums/queryKeys';
+import { useServerReachable } from '@/features/connectivity/useServerReachable';
 import { shareItem } from '@/utils/share';
 
 function formatDate(value: string | undefined): string {
@@ -46,11 +47,12 @@ export default function SharesScreen() {
   const density = useListDensity();
   const api = useApi();
   const queryClient = useQueryClient();
+  const serverReachable = useServerReachable();
 
   const sharesQuery = useQuery<Share[]>({
     queryKey: [QueryKeys.Shares],
     queryFn: async () => (await api.shares?.list()) ?? [],
-    enabled: Boolean(api.shares),
+    enabled: Boolean(api.shares) && serverReachable,
     staleTime: 1000 * 60 * 5,
   });
 
@@ -149,7 +151,12 @@ export default function SharesScreen() {
         title={t('shares.title')}
         subtitle={shareCount > 0 ? t('library.count.shares', { count: shareCount }) : undefined}
       />
-      {sharesQuery.isLoading ? (
+      {!serverReachable && !(sharesQuery.data ?? []).length ? (
+        <EmptyState
+          icon={<CloudOff size={iconSize.emptyState} color={colors.subtext} />}
+          message={t('common.offline.serverOnlyFeature')}
+        />
+      ) : sharesQuery.isLoading ? (
         <View style={styles.listContent}>
           {[...Array(6)].map((_, i) => <SkeletonListRow key={i} />)}
         </View>


### PR DESCRIPTION
The offline-first machinery covered the resources with a synced fallback and nothing else, so the surfaces without one degraded badly. This is the groundwork for WearOS (#133), where "no server" is the normal state rather than the exception.

## Search — two bugs, one of them silent

The server and Deezer legs were issued unconditionally. Offline, every keystroke started a request that hung to its own timeout, then landed in the same `catch` as a real failure and marked the whole search as errored — so the local results that *had* succeeded were shown underneath an error banner.

The second one was hiding underneath it. `searchScope` is a single value (`'client' | 'server'`), not a set, and its default is `'server'`. The old code tested it with `String.prototype.includes`, which reads as an array check. It happened to be correct, but it concealed the consequence: with the server unreachable there was no local leg to fall back to, so **an offline search over a fully synced library returned nothing at all.**

The legs are now decided up front in `contexts/searchLegs.ts` — pure, and tested with 7 cases. A server scope falls back to the local index; a skipped leg reports as `degraded` rather than as an error; and Deezer is gated on the device being online rather than on the *music server* being reachable, since a downed VPN takes the server away while the internet is fine.

## Surfaces with nothing to degrade to

Radio, podcasts and shares have no local equivalent, so they gate their query on reachability and render an offline empty state instead of spinning into a load failure. The two server-backed Home shelves do the same — the now-playing one had a 90s `refetchInterval`, so an unreachable server meant a request hanging on repeat behind a shelf that could never render.

Deezer-backed Home sections already handled this correctly via `useDeezerEnabled`; they are untouched.

## Also

- `useServerReachable` — the two existing signals together, since "can I call the server" was being asked in three different ways.
- Library index gets an offline banner.
- 8 locale keys across all four locales.
- `docs/architecture.md` §5 documents the two signals and which of three shapes a new surface belongs to.

## Verification

- `npm run lint` — 0 errors (52 pre-existing warnings, none in touched files)
- `npx tsc --noEmit` — clean
- `npx jest --ci` — **97 suites, 909 tests passing** (up from 96/902; the 7 new ones are `searchLegs`)

Not device-tested yet — the reachability paths want a real VPN-down run on hardware before this rides in a release.