### PR TITLE
Take the engine's now-playing fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "^1.0.1"
+        "yuzic-engine": "^1.0.2"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17954,9 +17954,9 @@
       }
     },
     "node_modules/yuzic-engine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.1.tgz",
-      "integrity": "sha512-54UdhmmfHfWyDqnBR75Zhh+zSGdd0lt6euNWIxpt1zIB8Hd0JIaz3v06UAlmQI6unZ0FIoWi2HO6Tl0yWJn17w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.2.tgz",
+      "integrity": "sha512-loc8+1Szz7C7fc+5z7MbY0cTxsj2GmF5Se5D25KpTIcLL4fCCHk8ODtCV8waTJSwOIw6tQ38AXkJZlqMpsFHJg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "^1.0.1"
+    "yuzic-engine": "^1.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Bumps `yuzic-engine` from `^1.0.1` to `^1.0.2`.

1.0.2 makes the Android media session follow the **active** voice for what is loaded, not just for where playback is. Before it, `EnginePlayer` forwarded the metadata/timeline getters to the *wrapped* voice rather than the live one — so after an odd number of crossfades the lock screen, notification and car display showed the previous track while the current one played.

The app already carried this fix in the repo but **not in the build**: the pin was `^1.0.1`, and 1.0.1 predates it. This is the pin drift AGENTS.md warns about, so I checked the artefact rather than the range — `node_modules/yuzic-engine` is 1.0.2 and the corrected `getMediaMetadata` / `getCurrentMediaItem` / `getCurrentTimeline` overrides are present in the installed Kotlin.

Engine side: PR yuzicapp/yuzic-engine#2, all four checks green (TS, parity, iOS core, Android build), released as [v1.0.2](https://github.com/yuzicapp/yuzic-engine/releases/tag/v1.0.2).

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (52 pre-existing warnings)
- `npx jest --ci` — 97 suites, 909 tests passing
- `package.json` `version` deliberately untouched, so this ships nothing on its own.

Not device-tested here; the engine fix itself was verified on device across a crossfade before release.