### PR TITLE
Tell gh which repo it is attaching to

### DIFF
--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -123,7 +123,13 @@ jobs:
       - name: Attach whatever built
         env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          # `gh` reads GH_REPO, not GITHUB_REPOSITORY. Without it, `gh release
+          # upload` shells out to git to work out which repo it is talking to,
+          # and this job never checks the repo out — so it died with "fatal:
+          # not a git repository" *after* both platforms had built and shipped,
+          # leaving 2.1.1 an empty draft with three artifacts stranded on the
+          # run. Setting GITHUB_REPOSITORY here looks right and does nothing.
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ needs.detect-version-bump.outputs.version }}
         run: |
           set -euo pipefail

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,8 +1,6 @@
-Playback holds up better on a stream that goes bad part-way through.
+Search and your library keep working when your server can't be reached.
 
-- A transcoded stream that breaks is picked back up instead of losing the track
-- Playback recovers where it used to stop and stay stopped
-- Fixes carried over from the audio engine
-
-Client certificates, for a server behind mutual TLS, are on iOS in this
-release. Android support still to come.
+- Searching offline now returns your synced library instead of nothing
+- Radio, podcasts and shares say they're offline rather than failing to load
+- Client certificates now work on Android, not only iOS
+- The lock screen and car display no longer show the previous track after a crossfade

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yuzic",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yuzic",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "@backpackapp-io/react-native-toast": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yuzic",
   "main": "expo-router/entry",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
The 2.1.1 release run showed as **failed** while 2.1.1 had actually shipped to both stores. This is the cause.

`gh release upload` reads **`GH_REPO`**. The attach job set `GITHUB_REPOSITORY`, which `gh` ignores, so it fell back to asking `git` which repo it was in — in a job that deliberately never checks the repo out, because all it needs are the downloaded artifacts.

```
ipa: artifacts/yuzic-ios/Yuzic.ipa
apk: artifacts/yuzic-android-apk/apk/release/app-release.apk
aab: artifacts/yuzic-android-aab/bundle/release/app-release.aab
failed to run git: fatal: not a git repository
```

All three artifacts were found and staged correctly. Only the upload call failed, and it failed **after** both platforms had built and uploaded to TestFlight and Play — leaving an empty draft release with the builds stranded as run artifacts.

The sibling `Create draft release` job *does* check out (line 66), which is why that half worked and kept this hidden. Swapping in `GH_REPO` is the whole fix; adding a checkout would also work but pulls the repo down just to name it.

2.1.1's assets were attached by hand after verifying them, so this PR is about the next release, not this one.

## Verification of the shipped run

- `Highest version code on Play: 135. Using Android version code: 136`
- `App Store Connect ... highest build number: 97. Using iOS build number: 98`

Both queried from the stores, both above what was held. Release APK re-checked locally: **0** `expo/modules/devlauncher` references.

No version change, so this ships nothing on its own.