### PR TITLE
Tell gh which repo it is attaching to

### DIFF
--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -123,7 +123,13 @@ jobs:
       - name: Attach whatever built
         env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          # `gh` reads GH_REPO, not GITHUB_REPOSITORY. Without it, `gh release
+          # upload` shells out to git to work out which repo it is talking to,
+          # and this job never checks the repo out — so it died with "fatal:
+          # not a git repository" *after* both platforms had built and shipped,
+          # leaving 2.1.1 an empty draft with three artifacts stranded on the
+          # run. Setting GITHUB_REPOSITORY here looks right and does nothing.
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ needs.detect-version-bump.outputs.version }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Promotes the attach-job fix from `dev` (#197) to `master`.

## Why now

The 2.1.1 release run showed **failed** while both stores had the build:

| Job | Result |
| --- | --- |
| Detect version bump | success |
| Create draft release | success |
| Ship Android build | success |
| Ship iOS build | success |
| Attach builds to the release | **failure** |

`gh release upload` reads **`GH_REPO`**, not `GITHUB_REPOSITORY`. The attach job
set the latter, which `gh` ignores, so it shelled out to git to work out which
repo it was talking to — inside a job that deliberately never checks out, since
all it needs are the downloaded artifacts. It died with `fatal: not a git
repository` *after* both platforms had built and uploaded to their stores,
leaving an empty draft release with the ipa, apk and aab stranded as run
artifacts. The sibling draft-release job does check out, which is why that half
worked and hid the bug.

2.1.1's assets were attached by hand and the release is published, so nothing is
outstanding for users. But `master` still carries the broken line, so **the next
version bump fails the same way** — and again only after both stores already
have the build.

## Release safety

This does **not** ship. `git diff origin/master...origin/dev -- package.json` is
empty; `version` stays at 2.1.1, so `release-on-version-bump.yml` will not fire.
Per AGENTS.md that puts this PR outside the version-bump gate.

Diff is one file, 7 insertions (6 of them the comment explaining the trap).
