### PR TITLE
Make the README tables answer one question each

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,23 @@ Yuzic provides a Navidrome demo but requires a self-hosted Subsonic, Jellyfin, o
 ## Servers
 
 You need one music server. Navidrome (or any Subsonic-compatible server),
-Jellyfin, and Emby are supported; Navidrome also has a built-in public demo you
-can try the app against without hosting anything.
+Jellyfin, and Emby are supported, each signed into with a username and
+password. Navidrome also has a built-in public demo you can try the app against
+without hosting anything.
 
-| Server | Auth | Demo | Radio | Podcasts | Shares | Queue sync | Resume positions |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| Navidrome / Subsonic | Username + password | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Jellyfin | Username + password | — | — | — | — | — | ✅ |
-| Emby | Username + password | — | — | — | — | — | ✅ |
+Everything not listed below — your library, playlists, favourites, search,
+lyrics, similar artists, and offline downloads — works the same on all three.
+What differs is the extras each server exposes:
+
+| Capability | Navidrome / Subsonic | Jellyfin | Emby |
+| --- | --- | --- | --- |
+| Resume positions | ✅ | ✅ | ✅ |
+| Radio | ✅ | — | — |
+| Podcasts | ✅ | — | — |
+| Shares | ✅ | — | — |
+| Jukebox — play on the server's own speakers | ✅ | — | — |
+| Queue sync across devices | ✅ | — | — |
+| Discovery shelves | ✅ | — | — |
 
 Provider-only surfaces are hidden rather than shown broken — a Jellyfin user
 doesn't get a Radio row that goes nowhere.
@@ -80,24 +89,25 @@ doesn't get a Radio row that goes nowhere.
 All optional, all off until you turn them on, all under
 **Settings → Integrations**.
 
-| Integration | Account needed | What it adds |
+| Integration | What it adds | Setup |
 | --- | --- | --- |
-| Deezer | No | Discovery shelves, search results, external artist/album pages, top tracks, similar artists, recommendations, 30s previews |
-| MusicBrainz | No | Canonical artist and album metadata for things not in your library |
-| Last.fm | No | Similar artists and playlist-recommendation seeds |
-| ListenBrainz | Token, for scrobbling | Scrobbling and now-playing; separately, the public similar-artist graph for discovery |
-| AudioMuse-AI | Self-hosted instance | Acoustic-similarity autoplay and playlist generation |
+| Deezer | Discovery shelves, search results, external artist/album pages, top tracks, similar artists, recommendations, 30s previews | Just turn it on |
+| MusicBrainz | Canonical artist and album metadata for things not in your library | Just turn it on |
+| Last.fm | Similar artists and playlist-recommendation seeds | Just turn it on |
+| ListenBrainz | Scrobbling and now-playing; separately, the public similar-artist graph for discovery | Token, for scrobbling |
+| AudioMuse-AI | Acoustic-similarity autoplay and playlist generation | Your own instance |
 
 ## Downloaders
 
 Optional, self-hosted, configured per server under **Settings → Downloaders**.
 These add music to *your server* — separate from offline downloads, which copy
-music you already have onto this device.
+music you already have onto this device. Both take a server URL and an API key.
 
-| Downloader | Albums | Tracks | Needs |
-| --- | --- | --- | --- |
-| [Lidarr](https://lidarr.audio) | ✅ | — | Server URL + API key |
-| [slskd](https://github.com/slskd/slskd) (Soulseek) | ✅ | ✅ | Server URL + API key |
+| Downloader | Albums | Tracks |
+| --- | --- | --- |
+| [Lidarr](https://lidarr.audio) | ✅ | — |
+| [slskd](https://github.com/slskd/slskd) (Soulseek) | ✅ | ✅ |
+| [SoulSync](https://github.com/Nezreka/SoulSync) | — | ✅ |
 
 ## Documentation
 
@@ -110,8 +120,8 @@ music you already have onto this device.
 
 ## Future
 - Apple TV app
-- Apple watch
-- F-droid
+- Apple Watch and Wear OS
+- F-Droid
 - Plex
 - Lyrion
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -183,6 +183,7 @@ without a manual pull (`src/features/downloaders/DownloadersQueueContext.tsx`).
 | --- | --- | --- | --- | --- |
 | [Lidarr](https://lidarr.audio) | Lidarr | ✅ | — (Lidarr is album-oriented) | Server URL + API key (Lidarr → Settings → General) |
 | [slskd](https://github.com/slskd/slskd) (Soulseek) | Soulseek | ✅ | ✅ | Server URL + API key, plus its own search preferences |
+| [SoulSync](https://github.com/Nezreka/SoulSync) | SoulSync | — (no album endpoint) | ✅ | Server URL + API key |
 
 Registry and the shared `DownloaderDefinition` shape:
 `src/features/downloaders/registry.ts`. A downloader is offered on an external
@@ -320,6 +321,25 @@ Nothing else on the Last.fm API is called — see
 slskd downloads also reach MusicBrainz (`src/api/slskd/mb/canonicalize.ts`) to
 turn an MBID into a canonical artist/album/track list before matching filenames
 against it.
+
+### SoulSync — your instance, `/api/v1`
+
+`Authorization: Bearer`. `src/api/soulsync/`. The query-param form (`?api_key=`)
+is also accepted, but a key in a URL ends up in logs and history, so the header
+is the one used.
+
+Every reply is wrapped in the same `{ success, data, error }` envelope whatever
+the HTTP status says; the client unwraps it so callers see `data` or an Error.
+
+| Endpoint | Used for |
+| --- | --- |
+| `GET /downloads?limit=1` | Connection test — SoulSync has no dedicated status endpoint, so the queue read doubles as one |
+| `POST /request` | Requesting a track. One free-text query; SoulSync runs its own search-match-download pipeline behind it |
+| `GET /downloads?limit=100` | The in-app transfer queue, and spotting finished items |
+| `POST /downloads/{id}/cancel` | Cancelling — takes the peer username in the body, since a transfer is addressed by id *and* peer |
+
+SoulSync is track-only: it exposes no album endpoint, which is why
+`downloadAlbum` is optional on `DownloaderDefinition`.
 
 ## What we don't call
 


### PR DESCRIPTION
Docs only — no `package.json` change, so this does not ship.

## Servers table

Eight columns, mostly dashes, and three separate problems:

- **`Auth` was a constant column** — "Username + password" in all three rows.
- **`Demo` isn't a capability.** It's a fact about the Navidrome *project*
  hosting a public server, sitting in a row of feature ticks answering a
  different question — and the prose directly above already said it.
- **The five feature columns were an arbitrary five of seven.** `ApiAdapter`
  declares `radio`, `shares`, `bookmarks`, `queue`, `discovery`, `podcasts`,
  `jukebox`. The table showed five, dropping `discovery` and `jukebox` — and
  jukebox is promoted in the Features list right above, so the table
  contradicted it by omission.

Jellyfin and Emby were also byte-identical rows, and the shape grows the wrong
way: Plex and Lyrion are on the Future list, and each new capability cost a
column on every row.

Transposed to capabilities-as-rows, which is what `docs/integrations.md`
already did. Four columns, grows downward, a new server is one column.

## The other two

`Downloaders` had `Needs` = "Server URL + API key" twice — constant, moved to
prose. `Integrations` had `Account needed` answering `No / No / No / "Token,
for scrobbling" / "Self-hosted instance"` — booleans and prose in one column;
now `Setup`, after `What it adds`.

## SoulSync was missing

Not just from the README — from `docs/integrations.md` entirely, despite being
in `ALL_DOWNLOADERS`. Added to both, with its endpoint table. It's track-only,
which is the reason `downloadAlbum` is optional on `DownloaderDefinition`.

## On checking

Every cell was verified against source rather than carried across — the
capability rows against each adapter's optional fields and
`capabilities.test.ts`, the SoulSync endpoints against `src/api/soulsync/`.

Worth recording one near-miss: an earlier draft added a row claiming Jellyfin
and Emby stream Opus where Navidrome doesn't, read off `streamableCodecs`.
That field is the set of codecs a server will **transcode into**, and yuzic
asks Subsonic for mp3 only — so the row would have advertised a capability
difference that doesn't exist. Dropped rather than published.
