### PR TITLE
Release 2.2.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,6 @@
   "expo": {
     "name": "Yuzic",
     "slug": "yuzic",
-    "version": "2.0.2",
     "orientation": "portrait",
     "icon": "./assets/images/logo.png",
     "scheme": "yuzic",

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,6 +1,6 @@
-Search and your library keep working when your server can't be reached.
+Swipe the cover art to change track, and playback speed that remembers.
 
-- Searching offline now returns your synced library instead of nothing
-- Radio, podcasts and shares say they're offline rather than failing to load
-- Client certificates now work on Android, not only iOS
-- The lock screen and car display no longer show the previous track after a crossfade
+- Swipe the cover on the player to go to the next or previous track
+- Playback speed is now remembered separately for music and for podcasts, and survives a restart
+- Continue Playing can resume a podcast episode instead of skipping it
+- Fixed downloads that could stop silently and reset with no explanation

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yuzic",
   "main": "expo-router/entry",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
Version bump to 2.2.0 plus the Play changelog. Merging this to `dev` ships nothing; the release fires when `dev` reaches `master`.

**Shipping in 2.2.0**
- Swipe the cover art to change track (#201)
- Playback speed remembered per profile (music / spoken), surviving restarts; Continue Playing can resume a podcast episode (#201)
- Downloads no longer fail silently when the background transfer service is unreachable (#203)
- Store screenshots regenerated from a simulator, and uploaded by the release for the first time (#203)

**Also drops `expo.version` from app.json.** It read 2.0.2 while the app shipped 2.1.1 — nothing has consumed it since versions stopped being set by hand. The workflows read the label from `package.json` with `jq` and inject it at build time (`MARKETING_VERSION` for iOS, `android.injected.version.name` for Gradle); the committed native projects carry equally stale defaults for the same reason. Expo falls back to `package.json` when the key is absent, verified with `expo config` now resolving 2.2.0.

Local gates green: tsc, lint, 933/933.