### PR TITLE
Release 2.2.0 to master

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,6 @@
   "expo": {
     "name": "Yuzic",
     "slug": "yuzic",
-    "version": "2.0.2",
     "orientation": "portrait",
     "icon": "./assets/images/logo.png",
     "scheme": "yuzic",

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,6 +1,6 @@
-Search and your library keep working when your server can't be reached.
+Swipe the cover art to change track, and playback speed that remembers.
 
-- Searching offline now returns your synced library instead of nothing
-- Radio, podcasts and shares say they're offline rather than failing to load
-- Client certificates now work on Android, not only iOS
-- The lock screen and car display no longer show the previous track after a crossfade
+- Swipe the cover on the player to go to the next or previous track
+- Playback speed is now remembered separately for music and for podcasts, and survives a restart
+- Continue Playing can resume a podcast episode instead of skipping it
+- Fixed downloads that could stop silently and reset with no explanation

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,6 +1,7 @@
 Swipe the cover art to change track, and playback speed that remembers.
 
 - Swipe the cover on the player to go to the next or previous track
-- Playback speed is now remembered separately for music and for podcasts, and survives a restart
+- Playback speed is now remembered separately for music and podcasts, and survives a restart
 - Continue Playing can resume a podcast episode instead of skipping it
-- Fixed downloads that could stop silently and reset with no explanation
+- Download buttons show real progress and the same finish everywhere
+- Fixed downloads that could stop silently with no explanation

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yuzic",
   "main": "expo-router/entry",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/src/components/DownloadStateIcon.tsx
+++ b/src/components/DownloadStateIcon.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect } from 'react';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withSpring,
+} from 'react-native-reanimated';
+import { Check, Download } from 'lucide-react-native';
+import DownloadProgressRing from '@/components/DownloadProgressRing';
+import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+import { iconSize } from '@/constants/design';
+
+type Props = {
+  isDownloaded: boolean;
+  isDownloading: boolean;
+  /**
+   * Aggregate progress in [0, 1]. Omit where the surface cannot measure it —
+   * an indeterminate spinner is drawn instead of a ring that would have to
+   * invent a number.
+   */
+  progress?: number;
+  color: string;
+  size?: number;
+};
+
+/** Overshoot and settle. The moment the download lands is worth marking. */
+const POP_IN = { damping: 8, stiffness: 200 };
+const POP_SETTLE = { damping: 10, stiffness: 200 };
+
+/**
+ * The download control's three states, in one place.
+ *
+ * This was written out separately on all four detail headers and had drifted
+ * into three different behaviours: album popped the checkmark in, playlist
+ * drew the same tick with no animation at all, and genre and artist showed an
+ * indeterminate spinner where the other two showed a determinate ring. Nothing
+ * about a genre makes its download less measurable — the progress was simply
+ * never passed. A user downloading an album and then a playlist saw the app
+ * congratulate itself once and stay silent the second time.
+ *
+ * Mounting already-downloaded is not an arrival, so the checkmark is only
+ * animated when `isDownloaded` becomes true while mounted. Revisiting a
+ * downloaded album would otherwise pop a tick for something that finished
+ * days ago.
+ */
+export default function DownloadStateIcon({
+  isDownloaded,
+  isDownloading,
+  progress,
+  color,
+  size = iconSize.row,
+}: Props) {
+  const reduced = useReducedMotion();
+  const scale = useSharedValue(isDownloaded ? 1 : 0);
+
+  useEffect(() => {
+    if (!isDownloaded) {
+      scale.value = 0;
+      return;
+    }
+    // Already at rest: this is a mount in the downloaded state, not an
+    // arrival, so there is nothing to announce.
+    if (scale.value === 1) return;
+    scale.value = reduced ? 1 : withSequence(withSpring(1.2, POP_IN), withSpring(1, POP_SETTLE));
+  }, [isDownloaded, reduced, scale]);
+
+  const style = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+
+  if (isDownloading) {
+    return progress === undefined ? (
+      <SpinningLoaderCircle size={size} color={color} />
+    ) : (
+      <DownloadProgressRing progress={progress} size={size} color={color} />
+    );
+  }
+
+  if (isDownloaded) {
+    return (
+      <Animated.View style={style}>
+        <Check size={size} color={color} />
+      </Animated.View>
+    );
+  }
+
+  return <Download size={size} color={color} />;
+}

--- a/src/contexts/PlayingContext.tsx
+++ b/src/contexts/PlayingContext.tsx
@@ -31,13 +31,14 @@ import { usePlaybackSink } from './PlaybackSinkContext';
 import { ownsPlayback } from '@/features/player/playbackSink';
 import { useScrobbling } from '@/hooks/useScrobbling';
 import { useCarPlayBrowseTree } from '@/hooks/useCarPlayBrowseTree';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   selectPreferredCodec,
   selectAutoplayEnabled,
   selectCrossfadeSeconds,
   selectCrossfadeAlways,
   selectEqualizerGains,
+  selectPlaybackSpeeds,
 } from '@/utils/redux/selectors/settingsSelectors';
 import { selectIsAudiomuseConfigured, selectAudiomuseConfig } from '@/utils/redux/selectors/audiomuseSelectors';
 import { useStreamQuality } from '@/hooks/useStreamQuality';
@@ -60,6 +61,8 @@ import {
 import { buildFillRequest, shouldFillQueue } from './autoplayFill';
 import { buildRestoredQueue } from './restoreQueue';
 import { canFillQueueFrom } from '@/utils/playback/contentKind';
+import { clampSpeed, speedFor, speedProfileFor } from '@/utils/playback/speedProfile';
+import { setPlaybackSpeedForProfile } from '@/utils/redux/slices/settingsSlice';
 import { useBookmarkManager } from '@/hooks/useBookmarkManager';
 import { useQueueSync } from '@/hooks/useQueueSync';
 import { usePlaybackPersistence } from '@/hooks/usePlaybackPersistence';
@@ -285,6 +288,13 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   const [repeatMode, setRepeatMode] = useState<RepeatModeState>('off');
   const [shuffleMode, setShuffleMode] = useState<ShuffleMode>('off');
   const [playbackSpeed, setPlaybackSpeedState] = useState(1.0);
+  // Read on every track change, which happens off the React render path, so
+  // a ref rather than the state value — the same pattern the bookmark map uses.
+  const playbackSpeedRef = useRef(1.0);
+  const playbackSpeeds = useSelector(selectPlaybackSpeeds);
+  const dispatch = useDispatch();
+  const playbackSpeedsRef = useRef(playbackSpeeds);
+  useEffect(() => { playbackSpeedsRef.current = playbackSpeeds; }, [playbackSpeeds]);
   const [volume, setVolumeState] = useState(1.0);
   const [queueVersion, setQueueVersion] = useState(0);
 
@@ -777,6 +787,17 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     const resumeSeconds = bookmarksRef.current.getResumePosition(songFromQueue.id);
     if (resumeSeconds && Math.floor(getBackend().getProgress().position) < 2) {
       getBackend().seekTo(resumeSeconds);
+    }
+
+    // Rate follows the kind of thing being played, not whatever was last set.
+    // One global speed meant a podcast at 1.5x carried into the next song, and
+    // reset to 1x on every launch — both wrong for the same reason, which is
+    // that talking and music are not listened to at the same rate.
+    const nextSpeed = speedFor(songFromQueue, playbackSpeedsRef.current);
+    if (nextSpeed !== playbackSpeedRef.current) {
+      playbackSpeedRef.current = nextSpeed;
+      setPlaybackSpeedState(nextSpeed);
+      getBackend().setPlaybackSpeed(nextSpeed);
     }
 
     submitNowPlayingRef.current(songFromQueue);
@@ -1299,9 +1320,18 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   }, []);
 
   const setPlaybackSpeed = useCallback((speed: number) => {
-    setPlaybackSpeedState(speed);
-    getBackend().setPlaybackSpeed(speed);
-  }, []);
+    const clamped = clampSpeed(speed);
+    playbackSpeedRef.current = clamped;
+    setPlaybackSpeedState(clamped);
+    getBackend().setPlaybackSpeed(clamped);
+    // Remembered against the kind of thing playing, so choosing 1.5x for a
+    // podcast does not follow the user into the next song — and survives a
+    // relaunch, which a listener halfway through a series expects.
+    dispatch(setPlaybackSpeedForProfile({
+      profile: speedProfileFor(currentSongRef.current),
+      speed: clamped,
+    }));
+  }, [dispatch]);
 
   const resetQueue = useCallback(async () => {
     await scrobbleOutgoingRef.current(

--- a/src/features/player/PlayerExpansion.tsx
+++ b/src/features/player/PlayerExpansion.tsx
@@ -90,6 +90,13 @@ type PlayerExpansionValue = {
    * it into the cover's opacity.
    */
   coverVisibility: SharedValue<number>;
+  /**
+   * Horizontal offset of the travelling cover while it is being swiped, in
+   * screen points. Lives here rather than on the playing screen because the
+   * cover itself is drawn by the host: the screen owns the *gesture* and the
+   * host owns the *view*, so the offset has to cross between them.
+   */
+  coverSwipeX: SharedValue<number>;
   expand: () => void;
   collapse: () => void;
   /** True from the moment the player starts opening until it is fully closed.
@@ -117,6 +124,7 @@ export const PlayerExpansionProvider: React.FC<{ children: ReactNode }> = ({ chi
   const fullCover = useSharedValue<CoverRect>(EMPTY_COVER_RECT);
   const scrollY = useSharedValue(0);
   const coverVisibility = useSharedValue(1);
+  const coverSwipeX = useSharedValue(0);
 
   const [isOpen, setIsOpen] = useState(false);
   const [hasOpened, setHasOpened] = useState(false);
@@ -150,13 +158,14 @@ export const PlayerExpansionProvider: React.FC<{ children: ReactNode }> = ({ chi
       fullCover,
       scrollY,
       coverVisibility,
+      coverSwipeX,
       expand,
       collapse,
       isOpen,
       hasOpened,
       prepare,
     }),
-    [expansion, barCover, fullCover, scrollY, coverVisibility, expand, collapse, isOpen, hasOpened, prepare],
+    [expansion, barCover, fullCover, scrollY, coverVisibility, coverSwipeX, expand, collapse, isOpen, hasOpened, prepare],
   );
 
   return (

--- a/src/features/player/PlayerHost.tsx
+++ b/src/features/player/PlayerHost.tsx
@@ -40,7 +40,7 @@ const NEUTRAL_GRADIENT: [string, string] = ['#121212', '#000'];
  * the other. They are one surface now, at a position the finger can hold.
  */
 export default function PlayerHost() {
-  const { expansion, barCover, fullCover, scrollY, coverVisibility, isOpen, hasOpened, collapse } =
+  const { expansion, barCover, fullCover, scrollY, coverVisibility, coverSwipeX, isOpen, hasOpened, collapse } =
     usePlayerExpansion();
   const { height, width } = useWindowDimensions();
   // The travelling cover is laid out once at a fixed size and only ever
@@ -164,7 +164,16 @@ export default function PlayerHost() {
       opacity: ready ? coverVisibility.value : 0,
       borderRadius: interpolate(e, [0, 1], [barRadius, cardRadius], Extrapolation.CLAMP) / scale,
       transform: [
-        { translateX: interpolate(e, [0, 1], [from.x, to.x], Extrapolation.CLAMP) },
+        {
+          // The swipe offset is scaled by `e` so it is at full strength on the
+          // open player and nothing at all in the dock: the same cover draws
+          // both, and a half-collapsed player should not carry a drag with it.
+          // Divided by `scale` because it is applied inside the scaled frame,
+          // so a raw value would move by scale-times the distance the finger did.
+          translateX:
+            interpolate(e, [0, 1], [from.x, to.x], Extrapolation.CLAMP) +
+            (coverSwipeX.value * e) / scale,
+        },
         { translateY: interpolate(e, [0, 1], [from.y, toY], Extrapolation.CLAMP) },
         { scale },
       ],

--- a/src/hooks/useBookmarkManager.ts
+++ b/src/hooks/useBookmarkManager.ts
@@ -11,6 +11,7 @@ import {
   setPlaybackBookmark,
 } from '@/utils/redux/slices/playbackSlice';
 import { isPodcastEpisode } from '@/utils/playback/contentKind';
+import { needsSnapshot, toBookmarkSnapshot } from '@/utils/playback/bookmarkSnapshot';
 
 /**
  * Bookmarks in yuzic:
@@ -95,7 +96,14 @@ export function useBookmarkManager() {
     }
 
     const positionMs = Math.floor(positionSeconds * 1000);
-    dispatch(setPlaybackBookmark({ songId: song.id, positionMs }));
+    dispatch(setPlaybackBookmark({
+      songId: song.id,
+      positionMs,
+      // Only for content the library cannot describe later. A library track
+      // is joined by id, so snapshotting it would freeze a title the user may
+      // since have re-tagged.
+      snapshot: needsSnapshot(song) ? toBookmarkSnapshot(song) : undefined,
+    }));
 
     if (supportsServer) {
       api.bookmarks!.create({ songId: song.id, positionMs }).catch(() => {});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -801,6 +801,10 @@
       "updateFavoritesFailed": "Failed to update favorites.",
       "randomAlbum": "Playing random album: {{title}}",
       "loadAlbumFailed": "Failed to load album."
+    },
+    "speed": {
+      "title": "Playback Speed",
+      "spokenTitle": "Speed (spoken)"
     }
   },
   "playlist": {
@@ -1177,7 +1181,8 @@
       "aboutArtist": "About the artist",
       "goToArtist": "Go to artist",
       "nowPlayingBar": "Now playing",
-      "noSongPlaying": "No song playing"
+      "noSongPlaying": "No song playing",
+      "coverArt": "Cover art. Swipe to change track."
     },
     "search": {
       "clear": "Clear search"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -799,6 +799,10 @@
       "updateFavoritesFailed": "Échec de la mise à jour des favoris.",
       "randomAlbum": "Lecture d'un album aléatoire : {{title}}",
       "loadAlbumFailed": "Échec du chargement de l'album."
+    },
+    "speed": {
+      "title": "Vitesse de lecture",
+      "spokenTitle": "Vitesse (parlé)"
     }
   },
   "playlist": {
@@ -1187,7 +1191,8 @@
       "aboutArtist": "À propos de l'artiste",
       "goToArtist": "Aller à l'artiste",
       "nowPlayingBar": "Lecture en cours",
-      "noSongPlaying": "Aucun morceau en lecture"
+      "noSongPlaying": "Aucun morceau en lecture",
+      "coverArt": "Pochette. Balayez pour changer de piste."
     },
     "search": {
       "clear": "Effacer la recherche"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -795,6 +795,10 @@
       "updateFavoritesFailed": "お気に入りの更新に失敗しました。",
       "randomAlbum": "ランダム再生: {{title}}",
       "loadAlbumFailed": "アルバムの読み込みに失敗しました。"
+    },
+    "speed": {
+      "title": "再生速度",
+      "spokenTitle": "速度（音声）"
     }
   },
   "playlist": {
@@ -1183,7 +1187,8 @@
       "aboutArtist": "アーティストについて",
       "goToArtist": "アーティストへ移動",
       "nowPlayingBar": "再生中",
-      "noSongPlaying": "再生中の曲はありません"
+      "noSongPlaying": "再生中の曲はありません",
+      "coverArt": "アルバムアート。スワイプで曲を変更します。"
     },
     "search": {
       "clear": "検索をクリア"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -795,6 +795,10 @@
       "updateFavoritesFailed": "更新收藏失败。",
       "randomAlbum": "正在播放随机专辑：{{title}}",
       "loadAlbumFailed": "加载专辑失败。"
+    },
+    "speed": {
+      "title": "播放速度",
+      "spokenTitle": "语音速度"
     }
   },
   "playlist": {
@@ -1183,7 +1187,8 @@
       "aboutArtist": "关于歌手",
       "goToArtist": "前往歌手页面",
       "nowPlayingBar": "正在播放",
-      "noSongPlaying": "没有正在播放的歌曲"
+      "noSongPlaying": "没有正在播放的歌曲",
+      "coverArt": "专辑封面。滑动可切换曲目。"
     },
     "search": {
       "clear": "清除搜索"

--- a/src/screens/album/components/Header/index.tsx
+++ b/src/screens/album/components/Header/index.tsx
@@ -1,15 +1,9 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { iconSize, spacing, statusColor } from '@/constants/design';
 import {
   StyleSheet,
 } from 'react-native';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSequence,
-  withSpring,
-} from 'react-native-reanimated';
-import { Ellipsis, Shuffle, Play, Check, Download, CloudDownload, Link } from 'lucide-react-native';
+import { Ellipsis, Shuffle, Play, CloudDownload, Link } from 'lucide-react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 
@@ -18,7 +12,7 @@ import AlbumOptions from '@/components/options/AlbumOptions';
 import DownloadSheet from '@/components/options/DownloadSheet';
 import StatusBanner from '@/components/StatusBanner';
 import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
-import DownloadProgressRing from '@/components/DownloadProgressRing';
+import DownloadStateIcon from '@/components/DownloadStateIcon';
 import { useCollectionDownloadProgress } from '@/hooks/useCollectionDownloadProgress';
 
 import { usePlayingActions } from '@/contexts/PlayingContext';
@@ -227,23 +221,6 @@ function LocalActionRow({ album }: { album: Album }) {
     getCollectionDownloadState(songIds);
   const downloadFraction = useCollectionDownloadProgress(songIds);
 
-  const checkmarkScale = useSharedValue(isAlbumDownloaded ? 1 : 0);
-
-  useEffect(() => {
-    if (isAlbumDownloaded) {
-      checkmarkScale.value = withSequence(
-        withSpring(1.2, { damping: 8, stiffness: 200 }),
-        withSpring(1, { damping: 10, stiffness: 200 })
-      );
-    } else {
-      checkmarkScale.value = 0;
-    }
-  }, [isAlbumDownloaded, checkmarkScale]);
-
-  const checkmarkStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: checkmarkScale.value }],
-  }));
-
   const toggleDownload = useCallback(async () => {
     if (isAlbumDownloading) {
       await cancelCollectionDownloads(album.id);
@@ -281,15 +258,12 @@ function LocalActionRow({ album }: { album: Album }) {
               : 'a11y.detail.download'
         )}
       >
-        {isAlbumDownloading ? (
-          <DownloadProgressRing progress={downloadFraction} size={iconSize.row} />
-        ) : isAlbumDownloaded ? (
-          <Animated.View style={checkmarkStyle}>
-            <Check size={iconSize.row} color={colors.secondary} />
-          </Animated.View>
-        ) : (
-          <Download size={iconSize.row} color={colors.secondary} />
-        )}
+        <DownloadStateIcon
+          isDownloaded={isAlbumDownloaded}
+          isDownloading={isAlbumDownloading}
+          progress={downloadFraction}
+          color={colors.secondary}
+        />
       </DetailCircleAction>
     </DetailActionRow>
   );

--- a/src/screens/artist/components/Header/index.tsx
+++ b/src/screens/artist/components/Header/index.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useNavigation } from '@react-navigation/native';
-import { ChevronLeft, Ellipsis, Shuffle, Play, Check, Download } from 'lucide-react-native';
+import { ChevronLeft, Ellipsis, Shuffle, Play } from 'lucide-react-native';
 import TurboImage from 'react-native-turbo-image';
 import { useSelector } from 'react-redux';
 import { MediaImage } from '@/components/MediaImage';
@@ -36,6 +36,8 @@ import {
   useDetailHeroTitleLayout,
 } from '@/components/DetailHeader';
 import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
+import DownloadStateIcon from '@/components/DownloadStateIcon';
+import { useCollectionDownloadProgress } from '@/hooks/useCollectionDownloadProgress';
 import Touchable from '@/components/Touchable';
 import { hitSlopFor, iconSize, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
@@ -316,6 +318,7 @@ function LocalActionRow({ artist }: { artist: Artist }) {
     isDownloaded: isArtistFullyDownloaded,
     isDownloading: isArtistDownloading,
   } = getCollectionDownloadState(artistTrackIds);
+  const downloadFraction = useCollectionDownloadProgress(artistTrackIds);
 
   const handleDownloadAll = useCallback(async () => {
     if (isDownloadingAll || isArtistDownloading || isArtistFullyDownloaded || !artistAlbums.length) return;
@@ -366,13 +369,13 @@ function LocalActionRow({ artist }: { artist: Artist }) {
               : 'a11y.detail.download'
         )}
       >
-        {isDownloadingAll || isArtistDownloading ? (
-          <SpinningLoaderCircle size={iconSize.row} color={colors.secondary} />
-        ) : isArtistFullyDownloaded ? (
-          <Check size={iconSize.row} color={colors.secondary} />
-        ) : (
-          <Download size={iconSize.row} color={colors.secondary} />
-        )}
+        <DownloadStateIcon
+          isDownloaded={isArtistFullyDownloaded}
+          isDownloading={isDownloadingAll || isArtistDownloading}
+          // Nothing to measure while the albums are still being enqueued.
+          progress={isDownloadingAll ? undefined : downloadFraction}
+          color={colors.secondary}
+        />
       </DetailCircleAction>
     </DetailActionRow>
   );

--- a/src/screens/genre/components/Header/index.tsx
+++ b/src/screens/genre/components/Header/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native'
 import { LinearGradient } from 'expo-linear-gradient'
 import { useNavigation } from '@react-navigation/native'
-import { ChevronLeft, Ellipsis, Shuffle, Play, Check, Download } from 'lucide-react-native'
+import { ChevronLeft, Ellipsis, Shuffle, Play } from 'lucide-react-native'
 import TurboImage from 'react-native-turbo-image'
 import { useSelector } from 'react-redux'
 import { toast } from '@backpackapp-io/react-native-toast'
@@ -35,6 +35,8 @@ import {
 } from '@/components/DetailHeader'
 import GenreOptions from '@/components/options/GenreOptions'
 import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
+import DownloadStateIcon from '@/components/DownloadStateIcon';
+import { useCollectionDownloadProgress } from '@/hooks/useCollectionDownloadProgress';
 import Touchable from '@/components/Touchable';
 import { controlSize, iconSize, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
@@ -83,6 +85,7 @@ const GenreHeader: React.FC<Props> = ({ genre, albums, showNavigation = true }) 
     isDownloaded: isFullyDownloaded,
     isDownloading,
   } = getCollectionDownloadState(genreTrackIds)
+  const downloadFraction = useCollectionDownloadProgress(genreTrackIds)
 
   const fetchGenreSongs = async (): Promise<Song[]> => {
     if (!activeServer?.id || !albums.length) return []
@@ -235,13 +238,15 @@ const GenreHeader: React.FC<Props> = ({ genre, albums, showNavigation = true }) 
                 : 'a11y.detail.download'
           )}
         >
-          {isDownloadingAll || isDownloading ? (
-            <SpinningLoaderCircle size={iconSize.row} color={colors.secondary} />
-          ) : isFullyDownloaded ? (
-            <Check size={iconSize.row} color={colors.secondary} />
-          ) : (
-            <Download size={iconSize.row} color={colors.secondary} />
-          )}
+          <DownloadStateIcon
+            isDownloaded={isFullyDownloaded}
+            isDownloading={isDownloadingAll || isDownloading}
+            // While `handleDownloadAll` is still enqueueing albums there is
+            // nothing to measure yet, so the spinner stands in until the
+            // tracks themselves start reporting.
+            progress={isDownloadingAll ? undefined : downloadFraction}
+            color={colors.secondary}
+          />
         </DetailCircleAction>
       </DetailActionRow>
     </>

--- a/src/screens/home/components/ContinuePlayingSection.tsx
+++ b/src/screens/home/components/ContinuePlayingSection.tsx
@@ -5,7 +5,9 @@ import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import type { Song } from '@/types';
+import { useApi } from '@/api';
 import { usePlayingActions } from '@/contexts/PlayingContext';
+import { songFromBookmarkSnapshot } from '@/utils/playback/bookmarkSnapshot';
 import { useTheme } from '@/hooks/useTheme';
 import { useRadius } from '@/hooks/useRadius';
 import { selectLibraryTracks } from '@/utils/redux/selectors/librarySelectors';
@@ -38,6 +40,7 @@ export default function ContinuePlayingSection() {
   const rad = useRadius();
   const { width: screenWidth } = useWindowDimensions();
   const { playSong } = usePlayingActions();
+  const api = useApi();
   const tracks = useSelector(selectLibraryTracks);
   const bookmarks = useSelector(selectPersistedPlaybackBookmarks);
 
@@ -46,16 +49,34 @@ export default function ContinuePlayingSection() {
     [screenWidth]
   );
 
-  // Bookmarks map is keyed by song id; join to the library and order by
-  // most-recent updatedAt. Any bookmark for a track no longer in the
-  // library is dropped — a stale entry with no title/cover is worse than
-  // a shorter row.
+  // Bookmarks map is keyed by song id; ordered by most-recent updatedAt.
+  //
+  // Two sources, because there are two kinds of entry. A library track is
+  // joined against the synced library, which stays authoritative for
+  // re-tagging and artwork — and a bookmark for a track no longer there is
+  // dropped, since a row with no title is worse than a shorter shelf.
+  //
+  // A podcast episode is never in that library: `buildPodcastSong` namespaces
+  // its id with `podcast:` exactly so it cannot collide with a real track, so
+  // the join can never match and every podcast bookmark used to fall through
+  // the same "no longer in the library" branch. Those carry a snapshot
+  // written beside the position, which is what draws them here.
   const entries = useMemo<Entry[]>(() => {
     const byId = new Map(tracks.map((t) => [t.id, t as unknown as Song]));
     return Object.entries(bookmarks)
       .map(([songId, entry]) => {
         const song = byId.get(songId);
-        return song ? { song, positionMs: entry.positionMs, updatedAt: entry.updatedAt } : null;
+        if (song) return { song, positionMs: entry.positionMs, updatedAt: entry.updatedAt };
+        if (entry.snapshot) {
+          return {
+            // The URL is rebuilt when the tile is tapped — the stored snapshot
+            // deliberately holds no credentialled one.
+            song: songFromBookmarkSnapshot(songId, entry.snapshot, ''),
+            positionMs: entry.positionMs,
+            updatedAt: entry.updatedAt,
+          };
+        }
+        return null;
       })
       .filter((e): e is Entry & { updatedAt: number } => e !== null)
       .sort((a, b) => b.updatedAt - a.updatedAt)
@@ -65,8 +86,19 @@ export default function ContinuePlayingSection() {
   const handlePress = useCallback((entry: Entry) => {
     // Player auto-resumes to the saved position when it loads — see
     // useBookmarkManager wiring in PlayingContext.
+    //
+    // A snapshot entry arrives with no stream URL, deliberately: the stored
+    // one would be signed with the user's token and this state is persisted.
+    // Build a fresh one now, from the id the snapshot did keep.
+    if (!entry.song.streamUrl && entry.song.streamId) {
+      void playSong({
+        ...entry.song,
+        streamUrl: api.songs.buildStreamUrl(entry.song.streamId, 'high'),
+      });
+      return;
+    }
     void playSong(entry.song);
-  }, [playSong]);
+  }, [api.songs, playSong]);
 
   const renderEntry = useCallback(({ item }: { item: Entry }) => (
     <MediaTile

--- a/src/screens/playing/components/PlaybackSpeedCard.tsx
+++ b/src/screens/playing/components/PlaybackSpeedCard.tsx
@@ -2,8 +2,10 @@ import React, { useCallback } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Gauge } from 'lucide-react-native';
 import { useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
 import { selectThemeColor } from '@/utils/redux/selectors/settingsSelectors';
 import { usePlayingActions, usePlayingState } from '@/contexts/PlayingContext';
+import { speedProfileFor } from '@/utils/playback/speedProfile';
 import {
   PLAYBACK_DEFAULT_SPEED,
   PLAYBACK_MAX_SPEED,
@@ -18,11 +20,15 @@ import { withAlpha } from '@/features/theme/coverAccent';
 type Props = { contentWidth: number };
 
 export default function PlaybackSpeedCard({ contentWidth }: Props) {
+  const { t } = useTranslation();
   const themeColor = useSelector(selectThemeColor);
   const rad = useRadius();
-  const { playbackSpeed } = usePlayingState();
+  const { playbackSpeed, currentSong } = usePlayingState();
   const { setPlaybackSpeed } = usePlayingActions();
   const isAltered = playbackSpeed !== 1.0;
+  // The card says which speed is being changed, because there are now two and
+  // a control that silently edits one of them is a control you cannot trust.
+  const isSpoken = speedProfileFor(currentSong) === 'spoken';
 
   const decrease = useCallback(() => {
     const next = Math.round((playbackSpeed - PLAYBACK_SPEED_STEP) * 100) / 100;
@@ -66,7 +72,7 @@ export default function PlaybackSpeedCard({ contentWidth }: Props) {
           color={isAltered ? themeColor : 'rgba(255,255,255,0.5)'}
         />
         <Text style={[styles.label, isAltered && { color: themeColor }]}>
-          Playback Speed
+          {t(isSpoken ? 'playing.speed.spokenTitle' : 'playing.speed.title')}
         </Text>
       </View>
 

--- a/src/screens/playing/components/PlayingMain.tsx
+++ b/src/screens/playing/components/PlayingMain.tsx
@@ -1,10 +1,11 @@
-import React, { memo, useCallback, useRef } from 'react';
+import React, { memo, useCallback, useMemo, useRef } from 'react';
 import {
   View,
   Text,
   StyleSheet,
 } from 'react-native';
-import { useAnimatedReaction, runOnJS } from 'react-native-reanimated';
+import { useAnimatedReaction, runOnJS, withSpring, withTiming } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 
 import { usePlayingState, usePlayingProgress, usePlayingActions } from '@/contexts/PlayingContext';
@@ -14,6 +15,7 @@ import { selectShowQualityBadge } from '@/utils/redux/selectors/settingsSelector
 import { hasFiniteDuration } from '@/utils/playback/contentKind';
 import { CirclePlus } from 'lucide-react-native';
 import { usePlayerExpansion } from '@/features/player/PlayerExpansion';
+import { resolveCoverSwipe } from '../coverSwipe';
 import Touchable from '@/components/Touchable';
 import { hitSlopFor, iconSize, onDark, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
@@ -24,6 +26,15 @@ type PlayingMainProps = {
   onPressOptions?: () => void;
   onPressAdd?: () => void;
 };
+
+// A swipe is unreachable with a screen reader on, so the same two outcomes are
+// offered as named actions. `increment`/`decrement` are what an `adjustable`
+// role advertises, which is how VoiceOver and TalkBack already expect to move
+// through a value.
+const SWIPE_A11Y_ACTIONS = [
+  { name: 'increment' as const },
+  { name: 'decrement' as const },
+];
 
 const formatTime = (seconds: number): string => {
   const mins = Math.floor(seconds / 60);
@@ -73,9 +84,10 @@ const PlayingMain: React.FC<PlayingMainProps> = ({
 }) => {
   const { t } = useTranslation();
   const { currentSong } = usePlayingState();
+  const { skipToNext, skipToPrevious } = usePlayingActions();
   const rad = useRadius();
   const showQualityBadge = useSelector(selectShowQualityBadge);
-  const { expansion, fullCover, scrollY } = usePlayerExpansion();
+  const { expansion, fullCover, scrollY, coverSwipeX } = usePlayerExpansion();
 
   // The cover itself is drawn by the player host, one layer up, so a single
   // image can travel between here and the playing bar instead of one being
@@ -100,10 +112,50 @@ const PlayingMain: React.FC<PlayingMainProps> = ({
     [measureCoverSlot],
   );
 
+  const handleAccessibilityAction = useCallback(
+    (event: { nativeEvent: { actionName: string } }) => {
+      if (event.nativeEvent.actionName === 'increment') void skipToNext();
+      else if (event.nativeEvent.actionName === 'decrement') void skipToPrevious();
+    },
+    [skipToNext, skipToPrevious],
+  );
+
+  const swipe = useMemo(
+    () =>
+      Gesture.Pan()
+        // Horizontal only. The player's own drag-to-close pan and the scroll
+        // view underneath both want vertical movement, so this one refuses it
+        // outright rather than racing them for it: without the Y limit a
+        // diagonal drag can start a skip and close the player at once.
+        .activeOffsetX([-12, 12])
+        .failOffsetY([-14, 14])
+        .onUpdate(event => {
+          coverSwipeX.value = event.translationX;
+        })
+        .onEnd(event => {
+          const outcome = resolveCoverSwipe(event.translationX, event.velocityX, width);
+          if (outcome === 'cancel') {
+            coverSwipeX.value = withSpring(0, { damping: 18, stiffness: 220 });
+            return;
+          }
+          // Carry the cover the rest of the way out before the track changes,
+          // then put it back at rest under the incoming artwork. Snapping to
+          // zero on the same frame as the skip reads as the cover flinching.
+          coverSwipeX.value = withTiming(
+            outcome === 'next' ? -width : width,
+            { duration: 140 },
+            finished => {
+              if (finished) coverSwipeX.value = 0;
+            },
+          );
+          runOnJS(outcome === 'next' ? skipToNext : skipToPrevious)();
+        }),
+    [coverSwipeX, width, skipToNext, skipToPrevious],
+  );
+
   if (!currentSong) {
     return null;
   }
-
   const qualityLabel = (() => {
     const parts: string[] = [];
     if (currentSong.mimeType) {
@@ -117,15 +169,25 @@ const PlayingMain: React.FC<PlayingMainProps> = ({
 
   return (
     <View style={[styles.root, { width }]}>
-      <View
-        ref={coverSlotRef}
-        onLayout={measureCoverSlot}
-        // Keeps its surface colour rather than going transparent: the
-        // travelling cover lands exactly on top of it, and a song whose
-        // artwork will not load still has the plain square it always had
-        // instead of a hole where the cover should be.
-        style={[styles.cover, { width, height: width, borderRadius: rad.card }]}
-      />
+      <GestureDetector gesture={swipe}>
+        <View
+          ref={coverSlotRef}
+          onLayout={measureCoverSlot}
+          // Keeps its surface colour rather than going transparent: the
+          // travelling cover lands exactly on top of it, and a song whose
+          // artwork will not load still has the plain square it always had
+          // instead of a hole where the cover should be.
+          style={[styles.cover, { width, height: width, borderRadius: rad.card }]}
+          // The square is what the finger swipes, but the cover the eye
+          // follows is drawn by the host with pointerEvents="none" — so this
+          // is also what a screen reader finds. Name it for what it does.
+          accessible
+          accessibilityRole="adjustable"
+          accessibilityLabel={t('a11y.player.coverArt')}
+          accessibilityActions={SWIPE_A11Y_ACTIONS}
+          onAccessibilityAction={handleAccessibilityAction}
+        />
+      </GestureDetector>
 
       <View style={styles.titleRow}>
         <View style={styles.textContainer}>

--- a/src/screens/playing/coverSwipe.test.ts
+++ b/src/screens/playing/coverSwipe.test.ts
@@ -1,0 +1,44 @@
+import { resolveCoverSwipe, SWIPE_DISTANCE_RATIO, SWIPE_VELOCITY } from './coverSwipe';
+
+const COVER = 300;
+const past = COVER * SWIPE_DISTANCE_RATIO + 1;
+const short = COVER * SWIPE_DISTANCE_RATIO - 1;
+
+describe('resolveCoverSwipe', () => {
+  it('skips forward when the cover is dragged left, the way the queue moves', () => {
+    expect(resolveCoverSwipe(-past, 0, COVER)).toBe('next');
+  });
+
+  it('goes back when it is dragged right', () => {
+    expect(resolveCoverSwipe(past, 0, COVER)).toBe('previous');
+  });
+
+  it('lets a short slow drag fall back', () => {
+    expect(resolveCoverSwipe(-short, 0, COVER)).toBe('cancel');
+    expect(resolveCoverSwipe(short, 0, COVER)).toBe('cancel');
+  });
+
+  it('takes a fast flick that never travelled far', () => {
+    expect(resolveCoverSwipe(-40, -SWIPE_VELOCITY - 1, COVER)).toBe('next');
+    expect(resolveCoverSwipe(40, SWIPE_VELOCITY + 1, COVER)).toBe('previous');
+  });
+
+  it('ignores a fast flick that went nowhere at all', () => {
+    // A tap that slipped a pixel can carry real velocity. Without the distance
+    // floor this is how a stray touch becomes a skipped track.
+    expect(resolveCoverSwipe(-2, -5000, COVER)).toBe('cancel');
+  });
+
+  it('reads direction from the drag, not the velocity', () => {
+    // Dragged well left, then pulled back at the last moment: velocity points
+    // right while the finger's net travel — the thing the user watched the
+    // cover do — is still left.
+    expect(resolveCoverSwipe(-past, SWIPE_VELOCITY * 2, COVER)).toBe('next');
+  });
+
+  it('scales its threshold with the cover, so a tablet is not twitchier', () => {
+    const wide = 900;
+    expect(resolveCoverSwipe(-past, 0, wide)).toBe('cancel');
+    expect(resolveCoverSwipe(-(wide * SWIPE_DISTANCE_RATIO + 1), 0, wide)).toBe('next');
+  });
+});

--- a/src/screens/playing/coverSwipe.ts
+++ b/src/screens/playing/coverSwipe.ts
@@ -1,0 +1,50 @@
+/**
+ * What a horizontal swipe across the cover art means.
+ *
+ * Pure so the thresholds can be tested without a gesture, a player, or a
+ * device — the same reason `contexts/searchLegs.ts` and
+ * `features/theme`'s `pickAccent` are pure.
+ */
+
+/** Fraction of the cover's width a drag must cross to count as a skip. */
+export const SWIPE_DISTANCE_RATIO = 0.28;
+
+/**
+ * Points per second past which a flick counts however short it was. A quick
+ * flick and a slow drag are both intentional; only a slow *short* one is not.
+ */
+export const SWIPE_VELOCITY = 500;
+
+export type SwipeOutcome = 'next' | 'previous' | 'cancel';
+
+/**
+ * Which way a completed swipe resolves.
+ *
+ * Direction is taken from the translation rather than the velocity: a drag
+ * that overshoots and is pulled back finishes with velocity pointing the wrong
+ * way, and the finger's net travel is what the user watched the cover do.
+ * Velocity only decides *whether* it counts, never which way.
+ *
+ * Dragging left (negative) pulls the next cover in from the right, so it means
+ * next — the same direction the queue moves.
+ */
+export function resolveCoverSwipe(
+  translationX: number,
+  velocityX: number,
+  coverWidth: number,
+): SwipeOutcome {
+  // Runs inside a gesture's `onEnd`, which is on the UI thread. Without this
+  // the call throws `Tried to synchronously call a non-worklet function` at
+  // the end of the first swipe — invisible to typecheck, lint and jest, all of
+  // which run it happily on the JS thread.
+  'worklet';
+  const far = Math.abs(translationX) > coverWidth * SWIPE_DISTANCE_RATIO;
+  const fast = Math.abs(velocityX) > SWIPE_VELOCITY;
+
+  // A flick has to have gone *somewhere*: velocity alone would fire on a tap
+  // that slipped a pixel, which is how a stray touch turns into a skipped
+  // track.
+  if (!far && !(fast && Math.abs(translationX) > 8)) return 'cancel';
+
+  return translationX < 0 ? 'next' : 'previous';
+}

--- a/src/screens/playlist/components/Header/index.tsx
+++ b/src/screens/playlist/components/Header/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { Ellipsis, Shuffle, Play, Check, Download } from 'lucide-react-native';
+import { Ellipsis, Shuffle, Play } from 'lucide-react-native';
 
 import { Playlist } from '@/types';
 import PlaylistOptions from '@/components/options/PlaylistOptions';
@@ -10,7 +10,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useTranslation } from 'react-i18next';
 import { useSheetRef } from '@/utils/useSheetRef';
 import { formatDuration } from '@/utils/formatDuration';
-import DownloadProgressRing from '@/components/DownloadProgressRing';
+import DownloadStateIcon from '@/components/DownloadStateIcon';
 import { useCollectionDownloadProgress } from '@/hooks/useCollectionDownloadProgress';
 import {
   DetailActionRow,
@@ -127,13 +127,12 @@ const PlaylistHeader: React.FC<Props> = ({ playlist, showNavigation = true, onOp
                     : 'a11y.detail.download'
               )}
             >
-              {isPlaylistDownloading ? (
-                <DownloadProgressRing progress={downloadFraction} size={iconSize.row} />
-              ) : isPlaylistDownloaded ? (
-                <Check size={iconSize.row} color={colors.secondary} />
-              ) : (
-                <Download size={iconSize.row} color={colors.secondary} />
-              )}
+              <DownloadStateIcon
+                isDownloaded={isPlaylistDownloaded}
+                isDownloading={isPlaylistDownloading}
+                progress={downloadFraction}
+                color={colors.secondary}
+              />
             </DetailCircleAction>
           </DetailActionRow>
         }

--- a/src/screens/settings/home/index.tsx
+++ b/src/screens/settings/home/index.tsx
@@ -23,6 +23,7 @@ import SettingsRow from '../components/SettingsRow';
 import Touchable from '@/components/Touchable';
 import { cappedTypography, fontScaleCap, iconSize, radius, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
+import { useScrollClearance } from '@/hooks/useScrollClearance';
 
 export default function Settings() {
     const { t } = useTranslation();
@@ -35,6 +36,12 @@ export default function Settings() {
 
     const { colors } = useTheme();
     const rad = useRadius();
+    // The version line is the last thing on this screen, so it is what sits
+    // behind the tabs when the dock is translucent and takes no layout space.
+    // The flat `spacing.scrollClearance` is only the breathing room; the hook
+    // adds the dock's real height, which changes with the safe-area inset and
+    // with whether a track is playing.
+    const scrollClearance = useScrollClearance();
     const appVersion = Constants.expoConfig?.version ?? '—';
 
     if (!activeServer) return null;
@@ -59,7 +66,7 @@ export default function Settings() {
         >
             <Header title={t('settings.title')} />
 
-            <ScrollView contentContainerStyle={styles.scrollContent}>
+            <ScrollView contentContainerStyle={[styles.scrollContent, { paddingBottom: scrollClearance }]}>
                 {/*
                   The card repeats what the sheet you arrived from already
                   showed — the same avatar, name, badge and host. Rather than

--- a/src/screens/settings/library/DownloadsInfoScreen.tsx
+++ b/src/screens/settings/library/DownloadsInfoScreen.tsx
@@ -22,11 +22,16 @@ import SettingsInfoRow from '../components/SettingsInfoRow';
 import Touchable from '@/components/Touchable';
 import { hitSlopFor, iconSize, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
+import { useScrollClearance } from '@/hooks/useScrollClearance';
 
 const DownloadsInfoScreen: React.FC = () => {
   const { t } = useTranslation();
   const { colors } = useTheme();
   const rad = useRadius();
+  // Same reason as the settings index: the flat constant is breathing room
+  // only, and the translucent dock takes no layout space, so the last download
+  // row would sit behind the tabs.
+  const scrollClearance = useScrollClearance();
   const activeServer = useSelector(selectActiveServer);
   const {
     removeDownloadByCollectionId,
@@ -121,7 +126,7 @@ const DownloadsInfoScreen: React.FC = () => {
   return (
     <SafeAreaView testID="downloads-info-screen" edges={['top']} style={[styles.container, { backgroundColor: colors.background }]}>
       <Header title={t('settings.library.downloads.detailsTitle')} />
-      <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
+      <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={[styles.scrollContent, { paddingBottom: scrollClearance }]}>
 
         <SettingsCard>
           <SettingsInfoRow label={t('settings.library.downloads.sizeLabel')} value={formattedSize} stacked />

--- a/src/types/Song.ts
+++ b/src/types/Song.ts
@@ -44,6 +44,17 @@ export interface Song extends SongBase {
     streamUrl: string;
     /** See {@link ContentKind}. Absent → treated as `'song'`. */
     contentKind?: ContentKind;
+    /**
+     * The server-side id `buildStreamUrl` was given, where that is not `id`.
+     *
+     * A podcast episode's id is namespaced (`podcast:…`) and its playable
+     * stream lives under a different id the server only assigns once it has
+     * downloaded the episode. Anything needing to rebuild the stream URL
+     * later — a resume shelf, an offline retry — needs that id rather than
+     * the one the queue is keyed by, and the credentialled URL is not safe to
+     * store.
+     */
+    streamId?: string;
     /** Source server ID; omitted when unknown. */
     sourceServerId?: string;
     /** Source server provider; omitted when unknown. */

--- a/src/utils/playback/bookmarkSnapshot.test.ts
+++ b/src/utils/playback/bookmarkSnapshot.test.ts
@@ -1,0 +1,104 @@
+import type { Song } from '@/types';
+import {
+  needsSnapshot,
+  songFromBookmarkSnapshot,
+  toBookmarkSnapshot,
+} from './bookmarkSnapshot';
+
+const librarySong: Song = {
+  id: 'track-1',
+  title: 'A Long Song',
+  artist: 'An Artist',
+  artistId: 'artist-1',
+  albumId: 'album-1',
+  cover: { kind: 'navidrome', coverArtId: 'art-1' },
+  duration: '2400',
+  streamUrl: 'https://music.example/rest/stream.view?id=track-1&t=SECRET&s=SALT',
+};
+
+const podcastSong: Song = {
+  ...librarySong,
+  id: 'podcast:ep-9',
+  streamId: 'stream-77',
+  title: 'Episode 9',
+  artist: 'A Show',
+  albumId: 'channel-3',
+  contentKind: 'podcastEpisode',
+};
+
+describe('needsSnapshot', () => {
+  it('does not snapshot a library track, which the library can still describe', () => {
+    expect(needsSnapshot(librarySong)).toBe(false);
+  });
+
+  it('snapshots a podcast episode, which the library never holds', () => {
+    expect(needsSnapshot(podcastSong)).toBe(true);
+  });
+
+  it('recognises a podcast by its id namespace even with the kind missing', () => {
+    // A Song rebuilt from an older snapshot may arrive without contentKind.
+    // The namespace is what actually decides whether the library join can
+    // succeed, so it is what this asks.
+    const { contentKind: _dropped, ...withoutKind } = podcastSong;
+    expect(needsSnapshot(withoutKind as Song)).toBe(true);
+  });
+});
+
+describe('toBookmarkSnapshot', () => {
+  it('never carries the stream URL, which is signed with the user token', () => {
+    // The slice is persisted, so a stored URL would put credentials on disk
+    // and pin them to whatever they were when the bookmark was written.
+    const snapshot = toBookmarkSnapshot(podcastSong);
+    expect(JSON.stringify(snapshot)).not.toContain('SECRET');
+    expect(JSON.stringify(snapshot)).not.toContain('stream.view');
+    expect('streamUrl' in snapshot).toBe(false);
+  });
+
+  it('keeps the stream id, which is what rebuilds the URL later', () => {
+    // Not the episode id: a podcast episode only gains a playable stream id
+    // once the server has downloaded it, and they are different values.
+    expect(toBookmarkSnapshot(podcastSong).streamId).toBe('stream-77');
+  });
+
+  it('keeps what a row needs to draw itself', () => {
+    const snapshot = toBookmarkSnapshot(podcastSong);
+    expect(snapshot.title).toBe('Episode 9');
+    expect(snapshot.artist).toBe('A Show');
+    expect(snapshot.cover).toEqual({ kind: 'navidrome', coverArtId: 'art-1' });
+    expect(snapshot.duration).toBe('2400');
+    expect(snapshot.channelId).toBe('channel-3');
+  });
+});
+
+describe('songFromBookmarkSnapshot', () => {
+  it('round-trips into something playable', () => {
+    const snapshot = toBookmarkSnapshot(podcastSong);
+    const rebuilt = songFromBookmarkSnapshot('podcast:ep-9', snapshot, 'https://fresh/url');
+
+    expect(rebuilt.id).toBe('podcast:ep-9');
+    expect(rebuilt.title).toBe('Episode 9');
+    expect(rebuilt.streamUrl).toBe('https://fresh/url');
+    expect(rebuilt.contentKind).toBe('podcastEpisode');
+  });
+
+  it('falls back to a letter cover rather than rendering a hole', () => {
+    const rebuilt = songFromBookmarkSnapshot(
+      'podcast:ep-1',
+      { title: 'No Art', artist: 'A Show' },
+      'https://fresh/url',
+    );
+    expect(rebuilt.cover).toEqual({ kind: 'letter', name: 'No Art' });
+  });
+
+  it('survives a snapshot written before duration was stored', () => {
+    // Persisted state outlives the shape that wrote it; a missing duration
+    // must not reach a progress bar as NaN.
+    const rebuilt = songFromBookmarkSnapshot(
+      'podcast:ep-2',
+      { title: 'Old', artist: 'A Show' },
+      'https://fresh/url',
+    );
+    expect(rebuilt.duration).toBe('0');
+    expect(Number(rebuilt.duration)).not.toBeNaN();
+  });
+});

--- a/src/utils/playback/bookmarkSnapshot.ts
+++ b/src/utils/playback/bookmarkSnapshot.ts
@@ -1,0 +1,67 @@
+import type { Song } from '@/types';
+import type { BookmarkSnapshot } from '@/utils/redux/slices/playbackSlice';
+import { isPodcastEpisode, PODCAST_EPISODE_ID_PREFIX } from './contentKind';
+
+/**
+ * Whether a resume position needs a stored snapshot to be renderable later.
+ *
+ * A library track does not: "Continue Playing" joins it against the synced
+ * library by id, which stays authoritative for re-tagging and artwork. A
+ * podcast episode is never in that library — `buildPodcastSong` namespaces its
+ * id with `podcast:` exactly so it cannot collide with a real track — so a
+ * bookmark with no snapshot is one nothing can draw.
+ *
+ * Keyed off the id namespace rather than `contentKind` alone, because the
+ * namespace is what actually decides whether the library join can succeed, and
+ * a Song rebuilt from a snapshot may arrive without its kind.
+ */
+export function needsSnapshot(song: Song): boolean {
+  return isPodcastEpisode(song) || song.id.startsWith(PODCAST_EPISODE_ID_PREFIX);
+}
+
+/**
+ * The credential-free part of a Song, for persisting beside a resume position.
+ *
+ * `streamUrl` is deliberately dropped. `buildStreamUrl` signs it with the
+ * user's token, and this ends up in a slice that is written to disk — storing
+ * it would put credentials in app storage and freeze them at whatever they
+ * were when the bookmark was written. The id is kept instead and the URL is
+ * rebuilt at play time.
+ */
+export function toBookmarkSnapshot(song: Song): BookmarkSnapshot {
+  return {
+    title: song.title,
+    artist: song.artist,
+    cover: song.cover,
+    duration: song.duration,
+    contentKind: song.contentKind,
+    streamId: song.streamId,
+    channelId: song.albumId || undefined,
+  };
+}
+
+/**
+ * Rebuild a playable Song from a stored snapshot.
+ *
+ * The caller supplies the stream URL because building one needs an api client
+ * bound to the active server, and this stays pure so it can be tested without
+ * one — the same split `podcastEpisodeToSong` already uses.
+ */
+export function songFromBookmarkSnapshot(
+  songId: string,
+  snapshot: BookmarkSnapshot,
+  streamUrl: string,
+): Song {
+  return {
+    id: songId,
+    title: snapshot.title,
+    artist: snapshot.artist,
+    artistId: '',
+    albumId: snapshot.channelId ?? '',
+    albumTitle: snapshot.artist,
+    cover: snapshot.cover ?? { kind: 'letter', name: snapshot.title },
+    duration: snapshot.duration ?? '0',
+    streamUrl,
+    contentKind: snapshot.contentKind,
+  };
+}

--- a/src/utils/playback/buildPodcastSong.ts
+++ b/src/utils/playback/buildPodcastSong.ts
@@ -27,6 +27,10 @@ export function podcastEpisodeToSong(
       : { kind: 'letter', name: channel?.title ?? episode.title },
     duration: String(episode.durationSeconds ?? 0),
     streamUrl,
+    // Kept so the URL can be rebuilt later without storing the signed one.
+    // Not the episode id: the server assigns this only once it has downloaded
+    // the episode, which is why `handlePlay` guards on it.
+    streamId: episode.playableStreamId ?? undefined,
     contentKind: 'podcastEpisode',
   };
 }

--- a/src/utils/playback/speedProfile.test.ts
+++ b/src/utils/playback/speedProfile.test.ts
@@ -1,0 +1,63 @@
+import type { Song } from '@/types';
+import {
+  clampSpeed,
+  MAX_SPEED,
+  MIN_SPEED,
+  speedFor,
+  speedProfileFor,
+} from './speedProfile';
+
+const song = { id: 's', title: 'A Song' } as Song;
+const episode = { id: 'podcast:e', title: 'An Episode', contentKind: 'podcastEpisode' } as Song;
+const stream = { id: 'radio:r', title: 'A Station', contentKind: 'liveStream' } as Song;
+
+describe('speedProfileFor', () => {
+  it('treats a podcast episode as spoken word', () => {
+    expect(speedProfileFor(episode)).toBe('spoken');
+  });
+
+  it('treats everything else as music', () => {
+    expect(speedProfileFor(song)).toBe('music');
+    expect(speedProfileFor(stream)).toBe('music');
+    expect(speedProfileFor(null)).toBe('music');
+  });
+});
+
+describe('speedFor', () => {
+  it('keeps the two profiles apart, which is the whole point', () => {
+    // Setting 1.5x for a podcast used to follow you into the next song.
+    const speeds = { music: 1.0, spoken: 1.5 };
+    expect(speedFor(episode, speeds)).toBe(1.5);
+    expect(speedFor(song, speeds)).toBe(1.0);
+  });
+
+  it('falls back for a user who upgraded before this setting existed', () => {
+    // undefined reaching the engine is a rate of NaN — silence with no error,
+    // which is the worst way for a missing setting to present.
+    expect(speedFor(episode, undefined)).toBe(1.0);
+    expect(speedFor(episode, {})).toBe(1.0);
+    expect(speedFor(song, { spoken: 2.0 })).toBe(1.0);
+  });
+
+  it('clamps a stored value that is out of range', () => {
+    expect(speedFor(episode, { spoken: 99 })).toBe(MAX_SPEED);
+    expect(speedFor(episode, { spoken: 0.01 })).toBe(MIN_SPEED);
+  });
+
+  it('survives a corrupted stored value rather than muting playback', () => {
+    expect(speedFor(episode, { spoken: NaN })).toBe(1.0);
+    expect(speedFor(episode, { spoken: Infinity })).toBe(1.0);
+  });
+});
+
+describe('clampSpeed', () => {
+  it('holds the useful listening range', () => {
+    expect(clampSpeed(1.5)).toBe(1.5);
+    expect(clampSpeed(5)).toBe(MAX_SPEED);
+    expect(clampSpeed(0)).toBe(MIN_SPEED);
+  });
+
+  it('answers 1x for a number that is not one', () => {
+    expect(clampSpeed(NaN)).toBe(1.0);
+  });
+});

--- a/src/utils/playback/speedProfile.ts
+++ b/src/utils/playback/speedProfile.ts
@@ -1,0 +1,57 @@
+import type { Song } from '@/types';
+import { getContentKind } from './contentKind';
+
+/**
+ * Which playback speed a track should use.
+ *
+ * Speed is one setting today, held in React state at 1.0 and never persisted,
+ * so it does three things a spoken-word listener notices immediately:
+ * it resets to 1× on every launch, it follows you out of a podcast into the
+ * next song, and it has to be set again for every episode.
+ *
+ * Splitting it by *profile* rather than by content kind keeps the stored shape
+ * small and stable: a listener wants one speed for talking and one for music,
+ * not a separate number per kind. A future `audiobook` kind joins `spoken`
+ * without changing anything that reads this.
+ */
+export type SpeedProfile = 'music' | 'spoken';
+
+export function speedProfileFor(song: Song | null | undefined): SpeedProfile {
+  return getContentKind(song) === 'podcastEpisode' ? 'spoken' : 'music';
+}
+
+/** What each profile starts at before the user has said otherwise. */
+export const DEFAULT_SPEEDS: Record<SpeedProfile, number> = {
+  music: 1.0,
+  spoken: 1.0,
+};
+
+/**
+ * The engine accepts a wide range, but the useful span for listening is
+ * narrower — and a rate the time-pitch unit cannot hold cleanly sounds broken
+ * rather than fast.
+ */
+export const MIN_SPEED = 0.5;
+export const MAX_SPEED = 3.0;
+
+export function clampSpeed(speed: number): number {
+  if (!Number.isFinite(speed)) return 1.0;
+  return Math.min(MAX_SPEED, Math.max(MIN_SPEED, speed));
+}
+
+/**
+ * The speed to apply for a track, given what the user has chosen per profile.
+ *
+ * Reads through a fallback rather than off the stored blob directly: a user
+ * upgrading has settings written before this key existed, and `undefined`
+ * reaching the engine is a rate of NaN — silence with no error, which is the
+ * worst way for a setting to be missing.
+ */
+export function speedFor(
+  song: Song | null | undefined,
+  speeds: Partial<Record<SpeedProfile, number>> | undefined,
+): number {
+  const profile = speedProfileFor(song);
+  const stored = speeds?.[profile];
+  return clampSpeed(typeof stored === 'number' ? stored : DEFAULT_SPEEDS[profile]);
+}

--- a/src/utils/redux/selectors/settingsSelectors.ts
+++ b/src/utils/redux/selectors/settingsSelectors.ts
@@ -12,6 +12,7 @@ import {
   LIBRARY_VIEW_DEFAULTS,
 } from '@/utils/redux/slices/settingsSlice';
 import type { ListDensity, RadiusPreset } from '@/constants/design';
+import type { SpeedProfile } from '@/utils/playback/speedProfile';
 
 export const selectSettings = (state: RootState) => state.settings;
 
@@ -208,3 +209,11 @@ const FLAT_GAINS: number[] = FLAT_EQ.map(band => band.gainDb);
 
 export const selectEqualizerGains = (state: RootState): number[] =>
   state.settings.equalizerGains ?? FLAT_GAINS;
+
+/**
+ * Remembered rates per kind of listening. Read through `speedFor`, never
+ * straight off this — a user upgrading has a blob written before the key
+ * existed, and an undefined rate reaching the engine is silence.
+ */
+export const selectPlaybackSpeeds = (state: RootState): Partial<Record<SpeedProfile, number>> =>
+  state.settings.playbackSpeeds ?? {};

--- a/src/utils/redux/slices/playbackSlice.ts
+++ b/src/utils/redux/slices/playbackSlice.ts
@@ -1,6 +1,38 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+import type { ContentKind, CoverSource } from '@/types';
 import type { RepeatModeState, ShuffleMode } from '@/contexts/PlayingContext';
+
+/**
+ * Enough of a track to draw it in a "pick back up" row without looking it up.
+ *
+ * Only stored for content that is not in the synced library — a podcast
+ * episode, whose id is namespaced so it can never join against it. A library
+ * track is drawn from the library, which stays authoritative for title
+ * changes, re-tagging and artwork.
+ *
+ * Carries `streamId` rather than `streamUrl`: the URL is credentialled and
+ * this slice is written to disk. See {@link PlaybackState.bookmarks}.
+ */
+export interface BookmarkSnapshot {
+  title: string;
+  artist: string;
+  /** Serialised the same way a Song's cover is, so surfaces render it with the
+   *  ordinary MediaImage path rather than a second code path. */
+  cover?: CoverSource;
+  /** Seconds, as `Song['duration']` carries it. */
+  duration?: string;
+  contentKind?: ContentKind;
+  /**
+   * The server-side id the stream URL is built from. For a podcast episode
+   * this is `playableStreamId`, which is not the episode id — an episode only
+   * has one once the server has downloaded it.
+   */
+  streamId?: string;
+  /** For a podcast episode: the channel it belongs to, so a surface can offer
+   *  a way back to the show. */
+  channelId?: string;
+}
 
 /**
  * The app's own memory of what it was playing — queue, current position,
@@ -36,8 +68,28 @@ export interface PlaybackState {
    * `updatedAt` lets "Continue Playing" surfaces order by recency without
    * a second index — the map is small enough (dozens of entries at most,
    * since it only holds long-form) that a full sort is free.
+   *
+   * `snapshot` is what a surface needs to *draw* the entry. Library tracks
+   * do not need it — they are joined against the synced library by id — but
+   * a podcast episode is not in that library and never will be: its id is
+   * namespaced (`podcast:…`) precisely so it cannot collide with one. Without
+   * a snapshot a podcast bookmark is unrenderable, which is why Continue
+   * Playing silently dropped every one of them.
+   *
+   * Deliberately not the whole Song. `streamUrl` carries an auth token
+   * (`buildStreamUrl` puts `t`/`s` in the query string) and this slice is
+   * persisted to disk, so storing it would write credentials into app
+   * storage and pin them to whatever they were when the bookmark was made.
+   * The URL is rebuilt from `streamId` at play time instead.
    */
-  bookmarks: Record<string, { positionMs: number; updatedAt: number }>;
+  bookmarks: Record<
+    string,
+    {
+      positionMs: number;
+      updatedAt: number;
+      snapshot?: BookmarkSnapshot;
+    }
+  >;
 }
 
 const initialState: PlaybackState = {
@@ -107,7 +159,11 @@ const playbackSlice = createSlice({
      */
     setPlaybackBookmark(
       state,
-      action: PayloadAction<{ songId: string; positionMs: number | null }>
+      action: PayloadAction<{
+        songId: string;
+        positionMs: number | null;
+        snapshot?: BookmarkSnapshot;
+      }>
     ) {
       if (action.payload.positionMs === null || action.payload.positionMs <= 0) {
         delete state.bookmarks[action.payload.songId];
@@ -115,6 +171,10 @@ const playbackSlice = createSlice({
         state.bookmarks[action.payload.songId] = {
           positionMs: Math.floor(action.payload.positionMs),
           updatedAt: Date.now(),
+          // Kept when this write does not carry one, so a caller that only
+          // knows the position cannot blank out a snapshot written earlier.
+          snapshot:
+            action.payload.snapshot ?? state.bookmarks[action.payload.songId]?.snapshot,
         };
       }
       state.updatedAt = Date.now();
@@ -128,7 +188,14 @@ const playbackSlice = createSlice({
       for (const [songId, positionMs] of Object.entries(action.payload)) {
         const existing = state.bookmarks[songId];
         if (existing && existing.updatedAt > now - 60_000) continue;
-        state.bookmarks[songId] = { positionMs, updatedAt: existing?.updatedAt ?? now - 60_000 };
+        state.bookmarks[songId] = {
+          positionMs,
+          updatedAt: existing?.updatedAt ?? now - 60_000,
+          // The server knows positions, not how to draw a row. Anything we
+          // already had stays — otherwise reconnecting would strip the
+          // snapshots and empty the shelf of exactly the entries that need one.
+          snapshot: existing?.snapshot,
+        };
       }
       state.updatedAt = now;
     },

--- a/src/utils/redux/slices/settingsSlice.ts
+++ b/src/utils/redux/slices/settingsSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { DEFAULT_LANGUAGE } from '@/constants/languages';
 import type { ListDensity, RadiusPreset } from '@/constants/design';
+import { clampSpeed, type SpeedProfile } from '@/utils/playback/speedProfile';
 
 export type LibrarySortOrder = 'title' | 'recent' | 'userplays' | 'year';
 
@@ -143,6 +144,18 @@ export interface SettingsState {
   /* Player controls */
   showSleepTimer: boolean;
   showPlaybackSpeed: boolean;
+  /**
+   * Remembered playback rate per kind of listening — see
+   * `utils/playback/speedProfile`. Two entries rather than one because a
+   * listener wants one speed for talking and another for music; a single
+   * global rate followed you out of a podcast into the next song and reset to
+   * 1× on every launch.
+   *
+   * Partial on purpose: a user upgrading has a settings blob written before
+   * this key existed, and every read goes through `speedFor`, which falls
+   * back rather than handing the engine an undefined rate.
+   */
+  playbackSpeeds: Partial<Record<SpeedProfile, number>>;
   showJumpButtons: boolean;
   showVolumeSlider: boolean;
   autoplayEnabled: boolean;
@@ -215,6 +228,7 @@ const initialState: SettingsState = {
 
   showSleepTimer: true,
   showPlaybackSpeed: false,
+  playbackSpeeds: {},
   showJumpButtons: false,
   showVolumeSlider: false,
   autoplayEnabled: false,
@@ -357,6 +371,16 @@ const settingsSlice = createSlice({
     setShowPlaybackSpeed(state, action: PayloadAction<boolean>) {
       state.showPlaybackSpeed = action.payload;
     },
+
+    /** Remember a rate for one kind of listening. Clamped here so a bad value
+     *  cannot reach the engine even if something writes one. */
+    setPlaybackSpeedForProfile(
+      state,
+      action: PayloadAction<{ profile: SpeedProfile; speed: number }>
+    ) {
+      if (!state.playbackSpeeds) state.playbackSpeeds = {};
+      state.playbackSpeeds[action.payload.profile] = clampSpeed(action.payload.speed);
+    },
     setShowJumpButtons(state, action: PayloadAction<boolean>) {
       state.showJumpButtons = action.payload;
     },
@@ -436,6 +460,7 @@ export const {
   setTranslucentDock,
   setRespectReducedMotion,
   setShowPlaybackSpeed,
+  setPlaybackSpeedForProfile,
   setAutoplayEnabled,
   setCrossfadeSeconds,
   setCrossfadeAlways,


### PR DESCRIPTION
**This ships.** `package.json` goes 2.1.1 -> 2.2.0, so merging fires `release-on-version-bump.yml`, which builds and uploads to TestFlight and Play alpha.

## What ships

- **Swipe the cover art to change track** — next/previous from the artwork on the player
- **Playback speed per profile** — one speed for music, one for spoken, both persisted. It was a single unsaved number that reset to 1x each launch and followed you out of a podcast
- **Continue Playing resumes podcast episodes** — it joins against the synced library by id, and an episode is never in that library, so the bookmark had nothing able to draw it
- **Downloads no longer fail silently** — when `nsurlsessiond` is unreachable every task on a background session fails and the app only sees `Code=-1 "unknown error"`; the button reverted to a plain arrow with no error. Now falls back to a foreground session

## First-time behaviour to watch

This is the **first release that uploads store screenshots**. Preflight done: 5 images per Play device type (cap is 8), sizes exactly 1242x2688 and 2048x2732, Play changelog 382/500 chars. Both listings will be replaced.

Expected numbers, given Play alpha held 136 and TestFlight held 98: `Using Android version code: 137` and `Using iOS build number: 99`. Anything much lower means something local answered instead of the store.

## After merge

Check **both** `Ship iOS build` and `Ship Android build` per-job, never the run conclusion — a run has shown FAILURE here with both platforms fully shipped. Then fill in the draft release, which is generated empty.