### PR TITLE
Note the download control work in the 2.2.0 release notes

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,6 +1,7 @@
 Swipe the cover art to change track, and playback speed that remembers.
 
 - Swipe the cover on the player to go to the next or previous track
-- Playback speed is now remembered separately for music and for podcasts, and survives a restart
+- Playback speed is now remembered separately for music and podcasts, and survives a restart
 - Continue Playing can resume a podcast episode instead of skipping it
-- Fixed downloads that could stop silently and reset with no explanation
+- Download buttons show real progress and the same finish everywhere
+- Fixed downloads that could stop silently with no explanation


### PR DESCRIPTION
PR #200 landed after the 2.2.0 bump was written, so the Play notes did not mention the one change a user actually sees on four screens. Version untouched; 437/500 characters.