### PR TITLE
Give every player drag exactly one exit

### DIFF
--- a/src/features/player/settle.test.ts
+++ b/src/features/player/settle.test.ts
@@ -1,0 +1,80 @@
+import {
+  settleFromBar,
+  settleFromPlayer,
+  OPEN_AT,
+  OPEN_VELOCITY,
+  CLOSE_BELOW,
+  CLOSE_VELOCITY,
+} from './settle';
+
+describe('settleFromBar', () => {
+  it('opens when the drag passes the threshold', () => {
+    expect(settleFromBar(OPEN_AT + 0.01, 0, true)).toBe(1);
+  });
+
+  it('falls back to the dock when it does not', () => {
+    expect(settleFromBar(OPEN_AT - 0.01, 0, true)).toBe(0);
+  });
+
+  it('takes a fast upward flick that never travelled far', () => {
+    expect(settleFromBar(0.05, OPEN_VELOCITY - 1, true)).toBe(1);
+  });
+
+  it('ignores a downward flick, which is not an open', () => {
+    expect(settleFromBar(0.05, 2000, true)).toBe(0);
+  });
+});
+
+describe('settleFromPlayer', () => {
+  it('stays open when barely pulled down', () => {
+    expect(settleFromPlayer(CLOSE_BELOW + 0.01, 0, true)).toBe(1);
+  });
+
+  it('closes once pulled past the threshold', () => {
+    expect(settleFromPlayer(CLOSE_BELOW - 0.01, 0, true)).toBe(0);
+  });
+
+  it('takes a decisive throw downward from near the top', () => {
+    expect(settleFromPlayer(0.99, CLOSE_VELOCITY + 1, true)).toBe(0);
+  });
+
+  it('ignores an upward flick, which cannot close', () => {
+    expect(settleFromPlayer(0.99, -2000, true)).toBe(1);
+  });
+});
+
+describe('a gesture that decided nothing', () => {
+  // The bug (#211): the close gesture returned early without settling when the
+  // player was fully open, so an interrupted pan left `expansion` wherever it
+  // stood — and the playing bar, which fades itself out by `expansion`, drew
+  // fully transparent while still mounted and still counted as open.
+  it('still names an end rather than leaving the value parked', () => {
+    expect(settleFromPlayer(1, 0, false)).toBe(1);
+    expect(settleFromPlayer(0.3, 0, false)).toBe(0);
+    expect(settleFromBar(0, 0, false)).toBe(0);
+  });
+
+  it('sends a stuck intermediate to the nearest end, never to itself', () => {
+    // Every value a finger can hold resolves to 0 or 1, so no exit can leave
+    // the bar invisible.
+    for (const e of [0, 0.001, 0.2, 0.3, 0.49, 0.5, 0.7, 0.9, 1]) {
+      expect([0, 1]).toContain(settleFromPlayer(e, 0, false));
+      expect([0, 1]).toContain(settleFromBar(e, 0, false));
+    }
+  });
+});
+
+describe('every outcome is an end', () => {
+  it('never returns an intermediate, whatever it is given', () => {
+    const values = [0, 0.15, 0.3, 0.5, 0.74, 0.75, 0.99, 1];
+    const velocities = [-2000, -700, -100, 0, 100, 700, 2000];
+    for (const e of values) {
+      for (const v of velocities) {
+        for (const moved of [true, false]) {
+          expect([0, 1]).toContain(settleFromBar(e, v, moved));
+          expect([0, 1]).toContain(settleFromPlayer(e, v, moved));
+        }
+      }
+    }
+  });
+});

--- a/src/features/player/settle.ts
+++ b/src/features/player/settle.ts
@@ -1,0 +1,91 @@
+/**
+ * Where a drag on the player lands when the finger lets go.
+ *
+ * Pure so the thresholds can be tested without a gesture, a player, or a
+ * device — the same reason `screens/playing/coverSwipe.ts` and
+ * `features/theme`'s `pickAccent` are pure.
+ *
+ * There are two of these rather than one because opening and closing are
+ * deliberately asymmetric: a short flick up opens the player, while closing it
+ * takes either a quarter of the screen or a decisive throw. The player is the
+ * thing you asked for; it should not fall out of your hand.
+ *
+ * Both answer `0` or `1` and nothing between. That is the point: **every** exit
+ * from a drag has to name an end. The bug this file exists to prevent is an
+ * exit that names nothing — `dragToClose.onEnd` used to `return` early when the
+ * player was fully open, so an interrupted gesture left `expansion` parked
+ * wherever it stood. The playing bar fades itself out by `expansion`, so a
+ * value stuck at 0.3 drew the bar fully transparent while it was still mounted,
+ * still holding its slot, and still counted as "open" by `CLOSED_EPSILON` —
+ * the mini player simply vanished with the music still playing (#211).
+ */
+
+/** Fraction of the screen an upward drag must cross to count as opening. */
+export const OPEN_AT = 0.3;
+
+/** Upward points per second past which a flick opens however short it was. */
+export const OPEN_VELOCITY = -700;
+
+/**
+ * How much of the drag *back* down is needed to stay open. Deliberately high:
+ * once the player is up, anything that looks like a dismissal is one.
+ */
+export const CLOSE_BELOW = 0.75;
+
+/** Downward points per second past which a throw closes however short it was. */
+export const CLOSE_VELOCITY = 700;
+
+/** Fully collapsed, fully open — never anything else. */
+export type Settled = 0 | 1;
+
+/**
+ * Where the player lands when a gesture that never actually moved it ends.
+ *
+ * A pan on the open player is a sibling of the scroll view's own gesture, so
+ * most of them are scrolls: the finger moves, the list moves, and `expansion`
+ * is never written. Such a gesture has decided nothing, so it must not be
+ * allowed to *look* like a decision — but it still has to name an end, because
+ * "leave it where it is" is exactly how a value gets stuck. Nearest end, which
+ * for an open player being scrolled is the one it is already at.
+ */
+function nearestEnd(expansion: number): Settled {
+  'worklet';
+  return expansion >= 0.5 ? 1 : 0;
+}
+
+/**
+ * Dragging up from the playing bar.
+ *
+ * @param moved whether the gesture ever wrote `expansion` at all.
+ */
+export function settleFromBar(
+  expansion: number,
+  velocityY: number,
+  moved: boolean,
+): Settled {
+  // Runs inside a gesture callback, which is on the UI thread. Without this the
+  // call throws `Tried to synchronously call a non-worklet function` at the end
+  // of the first drag — invisible to typecheck, lint and jest, all of which run
+  // it happily on the JS thread.
+  'worklet';
+  if (!moved) return nearestEnd(expansion);
+  if (velocityY < OPEN_VELOCITY) return 1;
+  return expansion > OPEN_AT ? 1 : 0;
+}
+
+/**
+ * Dragging down on the open player.
+ *
+ * @param moved whether the gesture ever wrote `expansion` at all — false for
+ *   the scrolls, which are most of them.
+ */
+export function settleFromPlayer(
+  expansion: number,
+  velocityY: number,
+  moved: boolean,
+): Settled {
+  'worklet';
+  if (!moved) return nearestEnd(expansion);
+  if (velocityY > CLOSE_VELOCITY) return 0;
+  return expansion < CLOSE_BELOW ? 0 : 1;
+}

--- a/src/screens/playing/index.tsx
+++ b/src/screens/playing/index.tsx
@@ -24,6 +24,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { PLAYER_SPRING, usePlayerExpansion } from '@/features/player/PlayerExpansion';
+import { settleFromPlayer } from '@/features/player/settle';
 import { useApi } from '@/api';
 import { LyricsResult } from '@/api/types';
 import { useAlbum } from '@/hooks/albums';
@@ -132,6 +133,11 @@ const PlayingScreen: React.FC<PlayingScreenProps> = ({
 
     const { expansion, scrollY, coverVisibility, isOpen } = usePlayerExpansion();
 
+    // Whether the pan below has actually moved the player, as opposed to being
+    // a scroll that its sibling gesture handled. A gesture that decided nothing
+    // must not settle as though it decided something — see `settle.ts`.
+    const dragMoved = useSharedValue(false);
+
     const handleScroll = useAnimatedScrollHandler(event => {
         scrollY.value = event.contentOffset.y;
     });
@@ -179,21 +185,34 @@ const PlayingScreen: React.FC<PlayingScreenProps> = ({
         () =>
             Gesture.Simultaneous(
                 Gesture.Pan()
+                    .onBegin(() => {
+                        dragMoved.value = false;
+                    })
                     .onUpdate(event => {
                         if (scrollY.value > 0 || event.translationY <= 0) return;
+                        dragMoved.value = true;
                         expansion.value = Math.max(0, Math.min(1, 1 - event.translationY / height));
                     })
-                    .onEnd(event => {
-                        if (expansion.value >= 1) return;
-                        const closing = expansion.value < 0.75 || event.velocityY > 700;
-                        expansion.value = withSpring(closing ? 0 : 1, PLAYER_SPRING);
+                    // `onFinalize`, not `onEnd`: a gesture that is cancelled or
+                    // interrupted — by the scroll view winning, by another
+                    // animation, by the touch being stolen — never reaches
+                    // `onEnd` at all, and that is the exit that used to leave
+                    // `expansion` parked at an intermediate value with the
+                    // playing bar faded to invisible (#211). `onFinalize` runs
+                    // for every ending, so there is exactly one way out and it
+                    // always names 0 or 1.
+                    .onFinalize(event => {
+                        expansion.value = withSpring(
+                            settleFromPlayer(expansion.value, event.velocityY, dragMoved.value),
+                            PLAYER_SPRING,
+                        );
                     }),
                 // Hands the scroll view's own gesture to RNGH so the two are
                 // siblings that may both run, rather than the pan swallowing
                 // every touch before the list ever sees it.
                 Gesture.Native(),
             ),
-        [expansion, height, scrollY],
+        [dragMoved, expansion, height, scrollY],
     );
 
     useEffect(() => {

--- a/src/screens/playing/playingBar/PlayingBarBase.tsx
+++ b/src/screens/playing/playingBar/PlayingBarBase.tsx
@@ -25,6 +25,7 @@ import {
   coverHandedOver,
   usePlayerExpansion,
 } from '@/features/player/PlayerExpansion';
+import { settleFromBar } from '@/features/player/settle';
 import { useTheme } from '@/hooks/useTheme';
 import {
   selectPlayingBarAction,
@@ -190,13 +191,16 @@ const variantStyles = {
 };
 
 /**
- * How far up the bar has to be dragged to count as a full open, and how fast a
- * flick has to be to count regardless of distance. A short sharp flick is how
- * most people open a player; a slow drag past a third of the screen is the
- * other way, and anything less falls back to the dock.
+ * The faintest the bar is drawn while the player is rising over it.
+ *
+ * Not zero, deliberately. By the quarter of the travel where this is reached
+ * the player's own surface is on its way over the dock, so the bar has
+ * something in front of it and does not need to be invisible to be unseen — and
+ * a value that can never reach zero is a bar that can never *disappear*, which
+ * is the failure mode of #211. The thresholds themselves live in
+ * `features/player/settle.ts` with the rest of the drag's arithmetic.
  */
-const OPEN_AT = 0.3;
-const OPEN_VELOCITY = -700;
+const BAR_MIN_OPACITY = 0.02;
 
 export default function PlayingBarBase({ variant }: Props) {
   const { t } = useTranslation();
@@ -208,6 +212,10 @@ export default function PlayingBarBase({ variant }: Props) {
   const { currentSong, isPlaying, isBuffering } = usePlayingState();
   const { pauseSong, resumeSong } = usePlayingActions();
   const { expansion, barCover, fullCover, expand, prepare } = usePlayerExpansion();
+
+  // Whether the drag below actually moved the player. A gesture that decided
+  // nothing must not settle as though it decided something — see `settle.ts`.
+  const dragMoved = useSharedValue(false);
 
   const stylesForVariant = variantStyles[variant];
   const playlistSheetRef = useSheetRef();
@@ -257,23 +265,37 @@ export default function PlayingBarBase({ variant }: Props) {
         .activeOffsetY([-10, 10])
         .failOffsetX([-24, 24])
         .onBegin(() => {
+          dragMoved.value = false;
           runOnJS(prepare)();
           runOnJS(measureCover)();
         })
         .onUpdate(event => {
+          dragMoved.value = true;
           expansion.value = Math.min(1, Math.max(0, -event.translationY / height));
         })
-        .onEnd(event => {
-          const opening = expansion.value > OPEN_AT || event.velocityY < OPEN_VELOCITY;
-          expansion.value = withSpring(opening ? 1 : 0, PLAYER_SPRING);
+        // `onFinalize` rather than `onEnd`, so a cancelled or interrupted drag
+        // settles too. An exit that names no end is what leaves the bar faded
+        // out with the music still playing (#211).
+        .onFinalize(event => {
+          expansion.value = withSpring(
+            settleFromBar(expansion.value, event.velocityY, dragMoved.value),
+            PLAYER_SPRING,
+          );
         }),
-    [currentSong, expansion, height, measureCover, prepare],
+    [currentSong, dragMoved, expansion, height, measureCover, prepare],
   );
 
   // The bar's own contents step aside early in the travel, leaving the cover
   // to make the journey on its own.
+  //
+  // Floored at the point the full player has actually covered the bar, so this
+  // can only ever hide the bar *behind something*. Fading to a true zero is
+  // what turned a stuck intermediate expansion into a bar that had vanished
+  // outright (#211): invisible, mounted, and still holding its slot in the
+  // dock. The gestures above now always settle, so nothing should park here —
+  // and if something ever does, it looks wrong rather than gone.
   const barFadeStyle = useAnimatedStyle(() => ({
-    opacity: interpolate(expansion.value, [0, 0.25], [1, 0], Extrapolation.CLAMP),
+    opacity: interpolate(expansion.value, [0, 0.25], [1, BAR_MIN_OPACITY], Extrapolation.CLAMP),
   }));
 
   // The thumbnail is handed over to the player host as soon as the host can


### PR DESCRIPTION
Fixes #211.

The mini player could vanish while a track was still playing — tab bar and blurred artwork intact, only the bar gone.

`PlayingBarBase` fades itself out by `expansion`, so any value left above 0.25 without the full player on screen draws the bar fully transparent while it is still mounted and still holding its slot. `isOpen` cannot correct it: `CLOSED_EPSILON` is 0.001, so a stuck 0.3 reads as "open" and nothing tries to collapse it.

The issue named `dragToClose.onEnd`s early return, which is one strandable exit. The larger one is that **`onEnd` does not run at all for a cancelled or interrupted gesture** — which is the case actually reported. So both gestures now settle in `onFinalize`, which runs for every ending, and the arithmetic moved to a pure `features/player/settle.ts` where every input resolves to 0 or 1 and nothing can return "leave it where it is".

A pan on the open player is a sibling of the scroll views own gesture, so most of them are scrolls that never write `expansion`. Those must not settle as though they decided something — hence `dragMoved` and the nearest-end rule.

`barFadeStyle` also floors at 0.02 rather than 0: by that point the players surface is over the dock, so the bar does not need to be invisible to be unseen, and a bar that can never reach zero opacity can never disappear outright. With the settle rule in place nothing should park there; if it ever does it looks wrong rather than gone.

`settle.ts` carries `'worklet'` because both callers reach it from a gesture on the UI thread. Typecheck, lint and jest all run it on the JS thread where it is an ordinary function, so none of them can catch its absence.

**Verified:** tsc clean, lint clean, 944 tests pass (11 new). Does not touch `package.json` `version`.
**Not verified:** the device swipe itself — worth a hardware check, since every off-device gate passes with a worklet bug in place.