### PR TITLE
Take engine 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yuzic",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yuzic",
-      "version": "2.1.1",
+      "version": "2.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@backpackapp-io/react-native-toast": "^0.13.0",
@@ -65,7 +65,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "^1.0.2"
+        "yuzic-engine": "^1.0.3"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17954,9 +17954,9 @@
       }
     },
     "node_modules/yuzic-engine": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.2.tgz",
-      "integrity": "sha512-loc8+1Szz7C7fc+5z7MbY0cTxsj2GmF5Se5D25KpTIcLL4fCCHk8ODtCV8waTJSwOIw6tQ38AXkJZlqMpsFHJg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.3.tgz",
+      "integrity": "sha512-VyY/dmELXnJdeNUjc0jEzJsS/vvpOqnXfCQAUh/17wBdMnxfduAan4mL4NaTS/GiqSs0tomem3pXhHoNqg41pw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "^1.0.2"
+    "yuzic-engine": "^1.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Carries the iOS fix for #212 into the app.

yuzic-engine 1.0.3 is published and the tarball is fetchable (polled to HTTP 200 rather than trusting `dist-tags` — metadata went green about four minutes before the tarball did, the usual two-stage lag).

**Verified against the artefact, not the range** — a caret quietly resolving to an older version is the pin drift AGENTS.md warns about:
- `node_modules/yuzic-engine/package.json` → `1.0.3`
- the fix is present in the installed `ios/Core/PlaybackEngine.swift`

tsc clean, 944 tests pass. Does not touch the app `package.json` `version`, so this ships nothing on its own.