### PR TITLE
Update Yuzic Engine to 1.0.4

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3407,20 +3407,23 @@ PODS:
     - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
-  - YuzicEngine (0.0.0):
+  - YuzicEngine (1.0.4):
     - ExpoModulesCore
-    - YuzicEngine/Core (= 0.0.0)
-  - YuzicEngine/Core (0.0.0):
+    - YuzicEngine/Core (= 1.0.4)
+  - YuzicEngine/Core (1.0.4):
     - ExpoModulesCore
+    - YuzicEngine/FLAC
     - YuzicEngine/Ogg
     - YuzicEngine/Opus
     - YuzicEngine/Vorbis
-  - YuzicEngine/Ogg (0.0.0):
+  - YuzicEngine/FLAC (1.0.4):
     - ExpoModulesCore
-  - YuzicEngine/Opus (0.0.0):
+  - YuzicEngine/Ogg (1.0.4):
+    - ExpoModulesCore
+  - YuzicEngine/Opus (1.0.4):
     - ExpoModulesCore
     - YuzicEngine/Ogg
-  - YuzicEngine/Vorbis (0.0.0):
+  - YuzicEngine/Vorbis (1.0.4):
     - ExpoModulesCore
     - YuzicEngine/Ogg
 
@@ -3960,7 +3963,7 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: b669e79fa0f8d3f6f5e35372345f54b99e06b13c
-  YuzicEngine: 9b3416dbf1bad48983a3f59fdfe60250d1b06127
+  YuzicEngine: 34cea83ea2a09566b75a30f04ca567123d54bace
 
 PODFILE CHECKSUM: 0a9d7fe2b7d7051d8f049cc799931b185ca60dc3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "^1.0.3"
+        "yuzic-engine": "^1.0.4"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17954,9 +17954,9 @@
       }
     },
     "node_modules/yuzic-engine": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.3.tgz",
-      "integrity": "sha512-VyY/dmELXnJdeNUjc0jEzJsS/vvpOqnXfCQAUh/17wBdMnxfduAan4mL4NaTS/GiqSs0tomem3pXhHoNqg41pw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.4.tgz",
+      "integrity": "sha512-1RGm66iE1RKe54tJ6JPlBYRhYMv9FLoStm0OBNY3XcffKIpKqiDpfAbsarHHIO9jNuTGOrUEfBw3YYmyAyFmzg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "^1.0.3"
+    "yuzic-engine": "^1.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- consume `yuzic-engine@1.0.4`, which includes libFLAC decoding and the CocoaPods header-map correction
- regenerate the iOS lockfile so the FLAC subspec is resolved at 1.0.4

Supports #213. No app version change.

## Verification
- clean Debug iPhone 17 Pro simulator build: `BUILD SUCCEEDED`
- installed package verified as `yuzic-engine@1.0.4`
- generated local podspec verified at 1.0.4 with the FLAC subspec