### PR TITLE
Fix playing-bar taps and animate cover changes

### DIFF
--- a/src/features/player/PlayerExpansion.tsx
+++ b/src/features/player/PlayerExpansion.tsx
@@ -6,6 +6,12 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
+import type { CoverSource } from '@/types/Cover';
+import {
+  enterCoverSlideWhenTrackChanges,
+  type CoverSlide,
+  type CoverSlideDirection,
+} from '@/screens/playing/coverTransition';
 import {
   useAnimatedReaction,
   useSharedValue,
@@ -68,6 +74,11 @@ export function coverHandedOver(
   return expansion > CLOSED_EPSILON && bar.size > 0 && full.size > 0;
 }
 
+type CoverSlideState = CoverSlide & {
+  /** The old image remains visible until playback has actually changed tracks. */
+  outgoingCover: CoverSource | null;
+};
+
 type PlayerExpansionValue = {
   /** 0 = collapsed to the bar, 1 = full screen. */
   expansion: SharedValue<number>;
@@ -97,6 +108,11 @@ type PlayerExpansionValue = {
    * host owns the *view*, so the offset has to cross between them.
    */
   coverSwipeX: SharedValue<number>;
+  /** The two-stage visual state for an accepted track swipe. */
+  coverSlide: CoverSlideState | null;
+  beginCoverSlide: (direction: CoverSlideDirection, songId: string, cover: CoverSource | null) => void;
+  enterCoverSlide: (currentSongId: string | undefined) => void;
+  finishCoverSlide: () => void;
   expand: () => void;
   collapse: () => void;
   /** True from the moment the player starts opening until it is fully closed.
@@ -128,6 +144,21 @@ export const PlayerExpansionProvider: React.FC<{ children: ReactNode }> = ({ chi
 
   const [isOpen, setIsOpen] = useState(false);
   const [hasOpened, setHasOpened] = useState(false);
+  const [coverSlide, setCoverSlide] = useState<CoverSlideState | null>(null);
+
+  const beginCoverSlide = useCallback(
+    (direction: CoverSlideDirection, songId: string, cover: CoverSource | null) => {
+      setCoverSlide({ direction, phase: 'exiting', outgoingSongId: songId, outgoingCover: cover });
+    },
+    [],
+  );
+  const enterCoverSlide = useCallback((currentSongId: string | undefined) => {
+    setCoverSlide(slide => slide && {
+      ...slide,
+      ...enterCoverSlideWhenTrackChanges(slide, currentSongId),
+    });
+  }, []);
+  const finishCoverSlide = useCallback(() => setCoverSlide(null), []);
 
   // One place decides what "open" means, so a tap, a drag that never
   // completed, and a spring settling back to zero all agree about it.
@@ -159,13 +190,21 @@ export const PlayerExpansionProvider: React.FC<{ children: ReactNode }> = ({ chi
       scrollY,
       coverVisibility,
       coverSwipeX,
+      coverSlide,
+      beginCoverSlide,
+      enterCoverSlide,
+      finishCoverSlide,
       expand,
       collapse,
       isOpen,
       hasOpened,
       prepare,
     }),
-    [expansion, barCover, fullCover, scrollY, coverVisibility, coverSwipeX, expand, collapse, isOpen, hasOpened, prepare],
+    [
+      expansion, barCover, fullCover, scrollY, coverVisibility, coverSwipeX,
+      coverSlide, beginCoverSlide, enterCoverSlide, finishCoverSlide,
+      expand, collapse, isOpen, hasOpened, prepare,
+    ],
   );
 
   return (

--- a/src/features/player/PlayerHost.tsx
+++ b/src/features/player/PlayerHost.tsx
@@ -2,7 +2,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { BackHandler, StyleSheet, useWindowDimensions, View } from 'react-native';
 import Animated, {
   interpolate,
+  runOnJS,
   useAnimatedStyle,
+  withTiming,
   Extrapolation,
 } from 'react-native-reanimated';
 import ImageColors from 'react-native-image-colors';
@@ -18,6 +20,8 @@ import PlayingScreen from '@/screens/playing';
 import PlayingBackground from '@/screens/playing/components/PlayingBackground';
 import { radius } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
+
+import { coverSlideOffset } from '@/screens/playing/coverTransition';
 
 import { coverHandedOver, usePlayerExpansion } from './PlayerExpansion';
 
@@ -40,8 +44,10 @@ const NEUTRAL_GRADIENT: [string, string] = ['#121212', '#000'];
  * the other. They are one surface now, at a position the finger can hold.
  */
 export default function PlayerHost() {
-  const { expansion, barCover, fullCover, scrollY, coverVisibility, coverSwipeX, isOpen, hasOpened, collapse } =
-    usePlayerExpansion();
+  const {
+    expansion, barCover, fullCover, scrollY, coverVisibility, coverSwipeX,
+    coverSlide, enterCoverSlide, finishCoverSlide, isOpen, hasOpened, collapse,
+  } = usePlayerExpansion();
   const { height, width } = useWindowDimensions();
   // The travelling cover is laid out once at a fixed size and only ever
   // scaled, so its width and height stay static styles rather than becoming
@@ -53,6 +59,26 @@ export default function PlayerHost() {
 
   const [currentGradient, setCurrentGradient] = useState<[string, string]>(['#000', '#000']);
   const [nextGradient, setNextGradient] = useState<[string, string]>(['#000', '#000']);
+
+  // A queue command changes React state asynchronously. Keep the old artwork
+  // on screen while it leaves, then place the replacement beyond the opposite
+  // edge before animating it in. A single image with its offset reset to zero
+  // can only ever look like a recoil — it cannot show both halves of a swipe.
+  useEffect(() => {
+    if (
+      !coverSlide || coverSlide.phase !== 'exiting' ||
+      !currentSong?.id || currentSong.id === coverSlide.outgoingSongId
+    ) return;
+
+    coverSwipeX.value = coverSlideOffset(coverSlide.direction, 'entering', width);
+    enterCoverSlide(currentSong.id);
+    const frame = requestAnimationFrame(() => {
+      coverSwipeX.value = withTiming(0, { duration: 220 }, finished => {
+        if (finished) runOnJS(finishCoverSlide)();
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [coverSlide, coverSwipeX, currentSong?.id, enterCoverSlide, finishCoverSlide, width]);
 
   const extractColors = useCallback(async (uri: string) => {
     const cached = gradientCache.get(uri);
@@ -180,6 +206,10 @@ export default function PlayerHost() {
     };
   });
 
+  const displayedCover = coverSlide?.phase === 'exiting'
+    ? coverSlide.outgoingCover
+    : currentSong?.cover;
+
   return (
     <View
       style={StyleSheet.absoluteFill}
@@ -207,7 +237,7 @@ export default function PlayerHost() {
         * shows the same placeholder when there is nothing to show. Building a
         * URL here by hand meant the host missed the server subscription that
         * makes those URLs resolve at all. */}
-      {currentSong?.cover && (
+      {displayedCover && (
         <Animated.View
           style={[
             styles.travellingCover,
@@ -216,7 +246,7 @@ export default function PlayerHost() {
           ]}
           pointerEvents="none"
         >
-          <MediaImage cover={currentSong.cover} size="detail" style={styles.coverFill} />
+          <MediaImage cover={displayedCover} size="detail" style={styles.coverFill} />
         </Animated.View>
       )}
     </View>

--- a/src/screens/playing/components/PlayingMain.tsx
+++ b/src/screens/playing/components/PlayingMain.tsx
@@ -16,6 +16,7 @@ import { hasFiniteDuration } from '@/utils/playback/contentKind';
 import { CirclePlus } from 'lucide-react-native';
 import { usePlayerExpansion } from '@/features/player/PlayerExpansion';
 import { resolveCoverSwipe } from '../coverSwipe';
+import { canStartCoverSlide } from '../coverTransition';
 import Touchable from '@/components/Touchable';
 import { hitSlopFor, iconSize, onDark, spacing, typography } from '@/constants/design';
 import { useRadius } from '@/hooks/useRadius';
@@ -83,11 +84,14 @@ const PlayingMain: React.FC<PlayingMainProps> = ({
   onPressAdd
 }) => {
   const { t } = useTranslation();
-  const { currentSong } = usePlayingState();
-  const { skipToNext, skipToPrevious } = usePlayingActions();
+  const { currentSong, currentIndex, repeatMode } = usePlayingState();
+  const { skipToNext, skipToPrevious, getQueue } = usePlayingActions();
+  const currentSongId = currentSong?.id;
+  const currentCover = currentSong?.cover ?? null;
+  const queueLength = getQueue().length;
   const rad = useRadius();
   const showQualityBadge = useSelector(selectShowQualityBadge);
-  const { expansion, fullCover, scrollY, coverSwipeX } = usePlayerExpansion();
+  const { expansion, fullCover, scrollY, coverSwipeX, beginCoverSlide } = usePlayerExpansion();
 
   // The cover itself is drawn by the player host, one layer up, so a single
   // image can travel between here and the playing bar instead of one being
@@ -134,23 +138,31 @@ const PlayingMain: React.FC<PlayingMainProps> = ({
         })
         .onEnd(event => {
           const outcome = resolveCoverSwipe(event.translationX, event.velocityX, width);
-          if (outcome === 'cancel') {
+          if (
+            !currentSongId || outcome === 'cancel' ||
+            !canStartCoverSlide(outcome, currentIndex, queueLength, repeatMode)
+          ) {
             coverSwipeX.value = withSpring(0, { damping: 18, stiffness: 220 });
             return;
           }
-          // Carry the cover the rest of the way out before the track changes,
-          // then put it back at rest under the incoming artwork. Snapping to
-          // zero on the same frame as the skip reads as the cover flinching.
+          // The old image gets its own exit. Only after that finishes can the
+          // queue select the next track; PlayerHost then puts that new image on
+          // the opposite edge and brings it in. Calling skip immediately was
+          // why the old implementation merely recoiled instead of becoming a
+          // real carousel transition.
+          runOnJS(beginCoverSlide)(outcome, currentSongId, currentCover);
           coverSwipeX.value = withTiming(
             outcome === 'next' ? -width : width,
             { duration: 140 },
             finished => {
-              if (finished) coverSwipeX.value = 0;
+              if (finished) runOnJS(outcome === 'next' ? skipToNext : skipToPrevious)();
             },
           );
-          runOnJS(outcome === 'next' ? skipToNext : skipToPrevious)();
         }),
-    [coverSwipeX, width, skipToNext, skipToPrevious],
+    [
+      beginCoverSlide, coverSwipeX, currentCover, currentIndex, currentSongId,
+      queueLength, repeatMode, skipToNext, skipToPrevious, width,
+    ],
   );
 
   if (!currentSong) {

--- a/src/screens/playing/coverTransition.test.ts
+++ b/src/screens/playing/coverTransition.test.ts
@@ -1,0 +1,52 @@
+import {
+  canStartCoverSlide,
+  coverSlideOffset,
+  enterCoverSlideWhenTrackChanges,
+  type CoverSlide,
+} from './coverTransition';
+
+describe('enterCoverSlideWhenTrackChanges', () => {
+  const exiting: CoverSlide = {
+    direction: 'next',
+    phase: 'exiting',
+    outgoingSongId: 'current',
+  };
+
+  it('keeps the outgoing cover in control until the player actually changes track', () => {
+    expect(enterCoverSlideWhenTrackChanges(exiting, 'current')).toBe(exiting);
+  });
+
+  it('starts the replacement cover offscreen only after the new track arrives', () => {
+    expect(enterCoverSlideWhenTrackChanges(exiting, 'next')).toEqual({
+      ...exiting,
+      phase: 'entering',
+    });
+  });
+});
+
+describe('coverSlideOffset', () => {
+  const width = 300;
+
+  it('moves an outgoing next cover left while the replacement enters from the right', () => {
+    expect(coverSlideOffset('next', 'exiting', width)).toBe(-width);
+    expect(coverSlideOffset('next', 'entering', width)).toBe(width);
+  });
+
+  it('mirrors the transition for previous', () => {
+    expect(coverSlideOffset('previous', 'exiting', width)).toBe(width);
+    expect(coverSlideOffset('previous', 'entering', width)).toBe(-width);
+  });
+});
+
+describe('canStartCoverSlide', () => {
+  it('does not strand the outgoing cover when the queue cannot advance', () => {
+    expect(canStartCoverSlide('next', 2, 3, 'off')).toBe(false);
+    expect(canStartCoverSlide('previous', 0, 3, 'off')).toBe(false);
+  });
+
+  it('allows an intentional queue move, including repeat-all from the end', () => {
+    expect(canStartCoverSlide('next', 1, 3, 'off')).toBe(true);
+    expect(canStartCoverSlide('previous', 1, 3, 'off')).toBe(true);
+    expect(canStartCoverSlide('next', 2, 3, 'all')).toBe(true);
+  });
+});

--- a/src/screens/playing/coverTransition.ts
+++ b/src/screens/playing/coverTransition.ts
@@ -1,0 +1,52 @@
+import type { SwipeOutcome } from './coverSwipe';
+
+export type CoverSlideDirection = Exclude<SwipeOutcome, 'cancel'>;
+export type CoverSlidePhase = 'exiting' | 'entering';
+
+/** A two-stage cover change: old art leaves before replacement art enters. */
+export type CoverSlide = {
+  direction: CoverSlideDirection;
+  phase: CoverSlidePhase;
+  /** The track that owns the artwork currently leaving the screen. */
+  outgoingSongId: string;
+};
+
+/**
+ * Keep rendering the outgoing cover until playback has actually selected its
+ * replacement. The player can reject a boundary skip, and React state reaches
+ * the host asynchronously, so starting the incoming animation earlier would
+ * either animate the old cover back in or flash the new one at the old edge.
+ */
+export function enterCoverSlideWhenTrackChanges(
+  slide: CoverSlide,
+  currentSongId: string | undefined,
+): CoverSlide {
+  if (slide.phase !== 'exiting' || !currentSongId || currentSongId === slide.outgoingSongId) {
+    return slide;
+  }
+  return { ...slide, phase: 'entering' };
+}
+
+/** The off-screen edge for either half of a directional cover transition. */
+export function coverSlideOffset(
+  direction: CoverSlideDirection,
+  phase: CoverSlidePhase,
+  width: number,
+): number {
+  const towardNext = direction === 'next' ? -1 : 1;
+  return phase === 'exiting' ? towardNext * width : -towardNext * width;
+}
+
+/** Whether the requested direction can actually select another queue item. */
+export function canStartCoverSlide(
+  direction: CoverSlideDirection,
+  currentIndex: number,
+  queueLength: number,
+  repeatMode: 'off' | 'all' | 'one',
+): boolean {
+  // Called from the cover pan's UI-thread callback.
+  'worklet';
+  if (queueLength <= 0) return false;
+  if (direction === 'previous') return currentIndex > 0;
+  return currentIndex < queueLength - 1 || repeatMode === 'all';
+}

--- a/src/screens/playing/playingBar/PlayingBarBase.tsx
+++ b/src/screens/playing/playingBar/PlayingBarBase.tsx
@@ -36,7 +36,7 @@ import { usePlayingBarAction } from './actions/usePlayingBarAction';
 import { useSheetRef } from '@/utils/useSheetRef';
 import SpinningLoaderCircle from '@/components/SpinningLoaderCircle';
 import Touchable from '@/components/Touchable';
-import { cappedTypography, fontScaleCap, hitSlopFor, iconSize, onDark, radius, spacing, typography } from '@/constants/design';
+import { cappedTypography, fontScaleCap, hitSlopFor, iconSize, onDark, radius, spacing } from '@/constants/design';
 
 type Variant = 'ios' | 'android';
 
@@ -262,7 +262,12 @@ export default function PlayingBarBase({ variant }: Props) {
     () =>
       Gesture.Pan()
         .enabled(currentSong != null)
-        .activeOffsetY([-10, 10])
+        // A tap belongs to the pressable. This pan activates only after a
+        // deliberate upward pull, and fails as soon as it becomes a downward
+        // movement, so ordinary finger settling cannot cancel `onPress` and
+        // make the player briefly rise then fall back into the dock.
+        .activeOffsetY(-18)
+        .failOffsetY(18)
         .failOffsetX([-24, 24])
         .onBegin(() => {
           dragMoved.value = false;


### PR DESCRIPTION
## What changed
- Give the mini-player press ownership of ordinary taps; only a deliberate upward pull activates the opening pan.
- Replace the cover swipe recoil with a two-stage transition: the old cover exits, playback changes tracks, and the replacement enters from the opposite edge.
- Do not start an exit animation at a queue boundary where no next/previous track exists.

## Verification
- `npx jest --ci --runInBand` — 103 suites / 955 tests passed
- `npx tsc --noEmit`
- focused ESLint and `git diff --check`

No `package.json` version change; this PR does not trigger a release.