### PR TITLE
Fix Jellyfin 12 password sign-in

### DIFF
--- a/src/api/mediaBrowser/auth/connect.test.ts
+++ b/src/api/mediaBrowser/auth/connect.test.ts
@@ -1,0 +1,27 @@
+import { connect } from './connect';
+import { JELLYFIN_BRAND } from '../brand';
+import { serverFetch } from '@/features/mtls/serverFetch';
+
+jest.mock('@/features/mtls/serverFetch', () => ({ serverFetch: jest.fn() }));
+jest.mock('../clientHeader', () => ({ mediaBrowserClientHeader: () => 'MediaBrowser Client="Yuzic"' }));
+
+const mockServerFetch = serverFetch as jest.MockedFunction<typeof serverFetch>;
+
+describe('MediaBrowser password authentication', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it('includes the application name Jellyfin 12 requires in the authentication body', async () => {
+    mockServerFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ AccessToken: 'token', User: { Id: 'user-1' } }),
+    } as Response);
+
+    await expect(connect(JELLYFIN_BRAND, 'https://music.example', 'zack', 'secret'))
+      .resolves.toEqual({ success: true, token: 'token', userId: 'user-1' });
+
+    expect(mockServerFetch).toHaveBeenCalledWith('https://music.example/Users/AuthenticateByName', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ Username: 'zack', Pw: 'secret', App: 'Yuzic' }),
+    }));
+  });
+});

--- a/src/api/mediaBrowser/auth/connect.ts
+++ b/src/api/mediaBrowser/auth/connect.ts
@@ -21,7 +21,9 @@ export async function connect(
         "X-Emby-Authorization": mediaBrowserClientHeader(),
         ...(basicAuth ? { Authorization: 'Basic ' + btoa(`${basicAuth.username}:${basicAuth.password}`) } : {}),
       },
-      body: JSON.stringify({ Username: username, Pw: password }),
+      // Jellyfin 12 rejects a password login whose body omits the application
+      // identity, even when the conventional client header names it.
+      body: JSON.stringify({ Username: username, Pw: password, App: 'Yuzic' }),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- include the required application identity in MediaBrowser password-login requests
- add a regression test for Jellyfin 12’s `request.App` requirement

Closes #225

## Verification
- `npm run lint`
- `npx tsc --noEmit`
- `npx jest --ci`

No version change; this is not a release PR.