### PR TITLE
feat: send request headers for Plex Basic-auth media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "react-redux": "^9.2.0",
         "reanimated-color-picker": "^4.2.0",
         "redux-persist": "^6.0.0",
-        "yuzic-engine": "^1.0.4"
+        "yuzic-engine": "^1.0.5"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17997,9 +17997,9 @@
       }
     },
     "node_modules/yuzic-engine": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.4.tgz",
-      "integrity": "sha512-1RGm66iE1RKe54tJ6JPlBYRhYMv9FLoStm0OBNY3XcffKIpKqiDpfAbsarHHIO9jNuTGOrUEfBw3YYmyAyFmzg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/yuzic-engine/-/yuzic-engine-1.0.5.tgz",
+      "integrity": "sha512-rqPl8VKhUJiqdnFwn7oMcOFetxEdxaXi8LcquARDIPa3DT4V43XCZn1fbun3XwyCFmn6WIEK0R/AuZxlKnw6Ww==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@expo/config-plugins": "*",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-redux": "^9.2.0",
     "reanimated-color-picker": "^4.2.0",
     "redux-persist": "^6.0.0",
-    "yuzic-engine": "^1.0.4"
+    "yuzic-engine": "^1.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/api/plex/client.ts
+++ b/src/api/plex/client.ts
@@ -22,6 +22,17 @@ function cleanBaseUrl(url: string): string {
 }
 
 /**
+ * The `Authorization: Basic` header for a reverse proxy in front of a server,
+ * or nothing when there is no Basic auth to send. The single construction of
+ * this value — the base64 of `user:pass` — lives here so a stream/artwork
+ * request built elsewhere reuses it rather than re-deriving credentials.
+ */
+export function plexBasicAuthHeader(basicAuth?: BasicAuth): Record<string, string> | undefined {
+  if (!basicAuth) return undefined;
+  return { Authorization: `Basic ${global.btoa(`${basicAuth.username}:${basicAuth.password}`)}` };
+}
+
+/**
  * Plex's server API is JSON when `Accept: application/json` is set. The
  * persistent client id is required by Plex and is deliberately the same
  * per-install identity MediaBrowser uses, never a launch-generated id.
@@ -35,8 +46,7 @@ export function plexHeaders(token?: string, basicAuth?: BasicAuth): Record<strin
     'X-Plex-Client-Identifier': getInstallationId(),
   };
   if (token) headers['X-Plex-Token'] = token;
-  if (basicAuth) headers.Authorization = `Basic ${global.btoa(`${basicAuth.username}:${basicAuth.password}`)}`;
-  return headers;
+  return { ...headers, ...plexBasicAuthHeader(basicAuth) };
 }
 
 export function createPlexClient(config: PlexClientConfig) {

--- a/src/contexts/DlnaContext.tsx
+++ b/src/contexts/DlnaContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { getBackend } from '@/features/player/activeBackend';
 import { getMediaItemUrl } from './playableMedia';
+import type { MediaItem } from '@/features/player/mediaItem';
 
 // ─── DLNA ────────────────────────────────────────────────────────────────────
 
@@ -8,6 +9,17 @@ export interface DlnaDevice {
   name: string;
   udn: string;
   avTransportUrl: string;
+}
+
+/**
+ * DLNA casts a bare URL to a renderer over SOAP and has no way to send request
+ * headers with it. A track that needs an `Authorization` header — a Plex behind
+ * a Basic-auth proxy — would 401 at the renderer, so it must not be cast as a
+ * URL that silently fails. Gate on the header the resolution path attaches
+ * rather than re-deriving the server type here.
+ */
+function requiresHeadersToPlay(item: MediaItem | null): boolean {
+  return !!item?.headers && Object.keys(item.headers).length > 0;
 }
 
 function xmlEscape(s: string): string {
@@ -80,6 +92,10 @@ export function DlnaProvider({ children }: { children: React.ReactNode }) {
     const unsubscribe = getBackend().addListener(async (event) => {
       if (event.type !== 'trackChange') return;
       const item = getBackend().getActiveMediaItem();
+      // A header-authenticated track cannot be cast as a bare URL — the
+      // renderer would 401. Leave it playing locally rather than pushing a URL
+      // that will fail silently on the device.
+      if (requiresHeadersToPlay(item)) return;
       const url = item ? getMediaItemUrl(item) : '';
       if (!url) return;
 
@@ -106,6 +122,12 @@ export function DlnaProvider({ children }: { children: React.ReactNode }) {
     setIsConnecting(true);
     try {
       const currentTrack = getBackend().getActiveMediaItem();
+      // See requiresHeadersToPlay: a Basic-auth Plex stream can't be cast to a
+      // URL-only renderer. Fail the connect explicitly rather than casting a
+      // URL that 401s with nothing to explain the silence.
+      if (requiresHeadersToPlay(currentTrack)) {
+        throw new Error('This server needs authentication that casting cannot send');
+      }
       const currentUrl = currentTrack ? getMediaItemUrl(currentTrack) : '';
       if (!currentUrl) throw new Error('No active track to cast');
 

--- a/src/contexts/DownloadContext.tsx
+++ b/src/contexts/DownloadContext.tsx
@@ -62,6 +62,7 @@ import {
   type LocalDownloadedTrackEntry,
 } from '@/utils/downloads/restore';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
+import { mediaHeadersForSong } from '@/features/player/mediaHeaders';
 import { selectDownloadOnWifiOnly, selectDownloadQuality } from '@/utils/redux/selectors/settingsSelectors';
 import { useNetworkType } from '@/hooks/useNetworkType';
 import { streamSourceId } from '@/utils/playback/streamId';
@@ -439,11 +440,17 @@ export const DownloadProvider: React.FC<{ children: ReactNode }> = ({ children }
         resolvedTrack.streamUrl,
       );
 
+      // A header-authenticated server (Plex behind Basic auth) rejects a bare
+      // download URL — the credentials ride in a request header, not the query
+      // string. Attach them to the file-download session the same way playback
+      // does, resolved against the active server. Unprotected servers add none.
+      const requestHeaders = mediaHeadersForSong(activeServer, resolvedTrack).headers;
+
       const runWithSession = async (options: typeof BACKGROUND_FILE_OPTIONS) => {
         const resumable = FileSystem.createDownloadResumable(
           resolvedTrack.streamUrl!,
           stagingPath,
-          options,
+          requestHeaders ? { ...options, headers: requestHeaders } : options,
           progress => reportDownloadProgress(
             track.id,
             progress.totalBytesWritten,
@@ -540,7 +547,7 @@ export const DownloadProvider: React.FC<{ children: ReactNode }> = ({ children }
       }
       setTrackDownloading(track.id, false);
     }
-  }, [activeServer?.id, activeServer?.type, clearDownloadProgress, isTrackDownloaded, isTrackDownloading, reportDownloadProgress, resolveTrack, setResumables, setTrackDownloading, updateCollections, updateTracks]);
+  }, [activeServer, clearDownloadProgress, isTrackDownloaded, isTrackDownloading, reportDownloadProgress, resolveTrack, setResumables, setTrackDownloading, updateCollections, updateTracks]);
 
   const removeJob = useCallback((jobId: string) => {
     updateJobs(jobs => jobs.filter(job => job.id !== jobId));

--- a/src/contexts/PlayingContext.tsx
+++ b/src/contexts/PlayingContext.tsx
@@ -21,6 +21,7 @@ import { Album, Playlist, Song, SongBase } from '@/types';
 import shuffleArray from '@/utils/shuffleArray';
 import { useApi } from '@/api';
 import { buildTrackItem } from '@/utils/builders/buildTrackItem';
+import { mediaHeadersForSong } from '@/features/player/mediaHeaders';
 import { toast } from '@backpackapp-io/react-native-toast';
 import { useTranslation } from 'react-i18next';
 import { moveSongAfterCurrent, reconcileUnshuffledQueue, QueueSegment, segmentAt, tagSegment, shiftSegmentsAfterInsert } from './playingQueue';
@@ -75,7 +76,7 @@ import {
   selectPersistedPlaybackRepeatMode,
   selectPersistedPlaybackShuffleMode,
 } from '@/utils/redux/selectors/playbackSelectors';
-import { selectActiveServerId as selectActiveServerIdSel } from '@/utils/redux/selectors/serversSelectors';
+import { selectActiveServerId as selectActiveServerIdSel, selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import { selectLibraryTracks } from '@/utils/redux/selectors/librarySelectors';
 import { clampStartIndex, trimQueueAroundIndex } from './adhocQueue';
 
@@ -232,8 +233,6 @@ const PlayingProgressProvider: React.FC<{ children: ReactNode }> = ({ children }
   );
 };
 
-const toMediaItems = (songs: Song[]): MediaItem[] => songs.map(buildTrackItem);
-
 export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const { t } = useTranslation();
   const isPlaying = usePlayerIsPlaying();
@@ -259,6 +258,27 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
   const preferredCodec = useSelector(selectPreferredCodec);
   const preferredCodecRef = useRef(preferredCodec);
   preferredCodecRef.current = preferredCodec;
+  // The active server, read through a ref so the header-attachment helpers
+  // below see the current one without rebuilding every transport handler.
+  // Its Basic-auth credentials are the source of the ephemeral request headers
+  // a protected Plex needs on both the stream and the artwork fetch.
+  const activeServer = useSelector(selectActiveServer);
+  const activeServerRef = useRef(activeServer);
+  activeServerRef.current = activeServer;
+
+  // Every Song->MediaItem crossing in this file goes through these two, so the
+  // header-attachment happens in exactly one place regardless of which
+  // consumer (foreground play, queue add, autoplay fill, play-next, restore)
+  // built the queue. Unprotected servers get an item identical to before.
+  const buildItem = useCallback(
+    (song: Song): MediaItem =>
+      buildTrackItem(song, mediaHeadersForSong(activeServerRef.current, song)),
+    []
+  );
+  const toMediaItems = useCallback(
+    (songs: Song[]): MediaItem[] => songs.map(buildItem),
+    [buildItem]
+  );
   const autoplayEnabled = useSelector(selectAutoplayEnabled);
 
   // Selected as primitives and rebuilt here rather than selected as objects.
@@ -702,7 +722,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     });
 
     return unsubscribe;
-  }, [t]);
+  }, [t, toMediaItems]);
 
   useEffect(() => {
     return getBackend().addListener(event => {
@@ -871,7 +891,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     );
     if (seekToPosition !== undefined && seekToPosition > 0) getBackend().seekTo(seekToPosition);
     if (play) getBackend().play();
-  }, [resetLastScrobbled, sinkLoadQueue]);
+  }, [resetLastScrobbled, sinkLoadQueue, toMediaItems]);
   // Assigned during render, not in an effect. React runs effects in the order
   // they are declared, and the auto-restore effect is declared far above this
   // one — so on first mount it called the placeholder this ref was
@@ -911,7 +931,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     } finally {
       isFillingRef.current = false;
     }
-  }, [bumpQueue]);
+  }, [bumpQueue, toMediaItems]);
   useEffect(() => { fillQueueIfLowRef.current = fillQueueIfLow; }, [fillQueueIfLow]);
 
   // Smart Shuffle's one-shot injection: fetches related tracks and shuffles
@@ -1061,7 +1081,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     });
     getBackend().addMediaItems(toMediaItems(toAdd));
     bumpQueue();
-  }, [bumpQueue, resolvePlayableSong]);
+  }, [bumpQueue, resolvePlayableSong, toMediaItems]);
 
   const shuffleCollectionToQueue = useCallback((collection: Album | Playlist) => {
     const existingIds = new Set(queueRef.current.map(s => s.id));
@@ -1080,7 +1100,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     });
     getBackend().addMediaItems(toMediaItems(toAdd));
     bumpQueue();
-  }, [bumpQueue, resolvePlayableSong]);
+  }, [bumpQueue, resolvePlayableSong, toMediaItems]);
 
   const skipToNext = useCallback(async () => {
     await scrobbleOutgoingRef.current(
@@ -1192,9 +1212,9 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
       contextId: playableSong.id,
       contextType: 'adhoc',
     });
-    getBackend().addMediaItems([buildTrackItem(playableSong)]);
+    getBackend().addMediaItems([buildItem(playableSong)]);
     bumpQueue();
-  }, [bumpQueue, resolvePlayableSong]);
+  }, [bumpQueue, resolvePlayableSong, buildItem]);
 
   const playNext = useCallback((song: Song) => {
     if (!currentSongRef.current) return;
@@ -1205,7 +1225,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     if (update.removedIndex !== null) {
       getBackend().moveMediaItem(update.removedIndex, update.insertIndex);
     } else {
-      getBackend().insertMediaItem(update.insertIndex, buildTrackItem(playableSong));
+      getBackend().insertMediaItem(update.insertIndex, buildItem(playableSong));
       queueSegmentsRef.current = tagSegment(
         shiftSegmentsAfterInsert(queueSegmentsRef.current, update.insertIndex, 1),
         update.insertIndex,
@@ -1217,7 +1237,7 @@ export const PlayingProvider: React.FC<{ children: ReactNode }> = ({ children })
     currentIndexRef.current = update.currentIndex;
     setCurrentIndex(update.currentIndex);
     bumpQueue();
-  }, [bumpQueue, resolvePlayableSong]);
+  }, [bumpQueue, resolvePlayableSong, buildItem]);
 
   // AudioMuse-AI first when configured, native similar-songs as fallback —
   // same tiered provider Autoplay and Smart Shuffle use, so "Play Similar"

--- a/src/features/player/browse.ts
+++ b/src/features/player/browse.ts
@@ -23,6 +23,17 @@ export interface BrowseItem {
   artworkUrl?: string;
   /** Set on playable rows. Its absence is what makes a row a folder. */
   url?: string;
+  /**
+   * Ephemeral request headers for a header-authenticated server (a Plex behind
+   * a Basic-auth proxy). `headers` fetches the audio, `artworkHeaders` the
+   * now-playing art once the leaf plays. Set only on playable rows and only
+   * when the active server needs them. Note the *browse-tree thumbnail*
+   * (`artworkUrl`) cannot carry headers — the engine's `BrowseNode` has no
+   * field for it — so protected-server art may not render in the browse list,
+   * though it does on the now-playing screen via `artworkHeaders`.
+   */
+  headers?: Record<string, string>;
+  artworkHeaders?: Record<string, string>;
   /** Seconds. */
   duration?: number;
   children?: BrowseItem[];

--- a/src/features/player/createEngineBackend.ts
+++ b/src/features/player/createEngineBackend.ts
@@ -55,6 +55,8 @@ function toBrowseNode(item: BrowseItem): BrowseNode {
           title: item.title,
           artist: item.artist,
           durationSec: item.duration,
+          ...(item.headers ? { headers: item.headers } : {}),
+          ...(item.artworkHeaders ? { artworkHeaders: item.artworkHeaders } : {}),
         }
       : undefined,
   };

--- a/src/features/player/engineBackend.test.ts
+++ b/src/features/player/engineBackend.test.ts
@@ -111,6 +111,36 @@ describe('translating between the app and the engine', () => {
       duration: 180,
     });
   });
+
+  it('wires audio and artwork headers into the two distinct engine fields', () => {
+    const track = toEngineTrack(item({
+      headers: { Authorization: 'Basic abc' },
+      artworkHeaders: { Authorization: 'Basic abc' },
+    }));
+    expect(track.headers).toEqual({ Authorization: 'Basic abc' });
+    expect(track.artworkHeaders).toEqual({ Authorization: 'Basic abc' });
+  });
+
+  it('leaves both header fields absent when the item carries none', () => {
+    const track = toEngineTrack(item());
+    expect(track).not.toHaveProperty('headers');
+    expect(track).not.toHaveProperty('artworkHeaders');
+  });
+
+  it('preserves both header fields across a round trip', () => {
+    const back = toMediaItem(toEngineTrack(item({
+      headers: { Authorization: 'Basic abc' },
+      artworkHeaders: { Authorization: 'Basic def' },
+    })));
+    expect(back.headers).toEqual({ Authorization: 'Basic abc' });
+    expect(back.artworkHeaders).toEqual({ Authorization: 'Basic def' });
+  });
+
+  it('keeps header fields absent across a round trip when unset', () => {
+    const back = toMediaItem(toEngineTrack(item()));
+    expect(back).not.toHaveProperty('headers');
+    expect(back).not.toHaveProperty('artworkHeaders');
+  });
 });
 
 describe('progress, in the shape the app expects', () => {

--- a/src/features/player/engineBackend.ts
+++ b/src/features/player/engineBackend.ts
@@ -118,6 +118,12 @@ export function toEngineTrack(item: MediaItem): Track {
     // Absent, not zero: the engine treats an unknown duration differently from
     // a zero one when it clamps a crossfade.
     durationSec: item.duration,
+    // Ephemeral request headers for a header-authenticated server (Plex behind
+    // a Basic-auth proxy). Two distinct fields: the engine fetches the stream
+    // and the artwork independently. Set only when present, so an unprotected
+    // server's Track is byte-for-byte what it was.
+    ...(item.headers ? { headers: item.headers } : {}),
+    ...(item.artworkHeaders ? { artworkHeaders: item.artworkHeaders } : {}),
   };
 }
 
@@ -131,6 +137,8 @@ export function toMediaItem(track: Track): MediaItem {
     duration: track.durationSec,
     url: track.uri,
     artworkUrl: track.artworkUri,
+    ...(track.headers ? { headers: track.headers } : {}),
+    ...(track.artworkHeaders ? { artworkHeaders: track.artworkHeaders } : {}),
   };
 }
 

--- a/src/features/player/mediaHeaders.test.ts
+++ b/src/features/player/mediaHeaders.test.ts
@@ -1,0 +1,92 @@
+import type { Server, Song } from '@/types';
+import { mediaHeadersForSong } from './mediaHeaders';
+
+// btoa may be absent in the jest environment; the Plex client's header builder
+// uses global.btoa exactly as the app does at runtime.
+if (typeof global.btoa !== 'function') {
+  global.btoa = (s: string) => Buffer.from(s, 'binary').toString('base64');
+}
+
+const song = (over: Partial<Song> = {}): Song => ({
+  id: 'song-1',
+  title: 'Song',
+  artist: 'Artist',
+  artistId: 'artist-1',
+  albumId: 'album-1',
+  cover: { kind: 'none' },
+  duration: '120',
+  streamUrl: 'https://plex.example/library/parts/1/file.mp3?X-Plex-Token=t',
+  ...over,
+});
+
+const server = (over: Partial<Server> = {}): Server => ({
+  id: 'srv-1',
+  type: 'plex',
+  serverUrl: 'https://plex.example',
+  username: 'zack',
+  isAuthenticated: true,
+  ...over,
+});
+
+const expectedAuth = `Basic ${global.btoa('proxy-user:proxy-password')}`;
+
+describe('mediaHeadersForSong', () => {
+  it('attaches the Basic auth header to both audio and artwork for a Basic-auth Plex server', () => {
+    const result = mediaHeadersForSong(
+      server({ basicAuth: { username: 'proxy-user', password: 'proxy-password' } }),
+      song()
+    );
+    expect(result.headers).toEqual({ Authorization: expectedAuth });
+    expect(result.artworkHeaders).toEqual({ Authorization: expectedAuth });
+  });
+
+  it('yields no headers for a token-only Plex server (no Basic auth)', () => {
+    const result = mediaHeadersForSong(server({ basicAuth: undefined }), song());
+    expect(result.headers).toBeUndefined();
+    expect(result.artworkHeaders).toBeUndefined();
+  });
+
+  it('yields no headers for a Navidrome server even with Basic auth set', () => {
+    // Navidrome signs its URLs; a Basic-auth field here would be a proxy for a
+    // different provider and must not leak onto Plex-style header auth.
+    const result = mediaHeadersForSong(
+      server({ type: 'navidrome', basicAuth: { username: 'u', password: 'p' } }),
+      song()
+    );
+    expect(result.headers).toBeUndefined();
+    expect(result.artworkHeaders).toBeUndefined();
+  });
+
+  it('yields no headers when there is no active server', () => {
+    expect(mediaHeadersForSong(null, song())).toEqual({});
+    expect(mediaHeadersForSong(undefined, song())).toEqual({});
+  });
+
+  it('skips a locally-downloaded track even on a Basic-auth Plex server', () => {
+    // A file:// path is already on disk and needs no server credentials.
+    const result = mediaHeadersForSong(
+      server({ basicAuth: { username: 'proxy-user', password: 'proxy-password' } }),
+      song({ streamUrl: 'file:///downloads/audio/song-1.mp3' })
+    );
+    expect(result).toEqual({});
+  });
+
+  it('honours a mixed-queue song whose own source is a Basic-auth Plex', () => {
+    // sourceServerType overrides the active server's type, so a Plex track in a
+    // queue while another provider is active still gets its Plex headers.
+    const result = mediaHeadersForSong(
+      server({ type: 'plex', basicAuth: { username: 'proxy-user', password: 'proxy-password' } }),
+      song({ sourceServerType: 'plex' })
+    );
+    expect(result.headers).toEqual({ Authorization: expectedAuth });
+    expect(result.artworkHeaders).toEqual({ Authorization: expectedAuth });
+  });
+
+  it('skips a song whose source names a non-Plex provider', () => {
+    const result = mediaHeadersForSong(
+      server({ type: 'plex', basicAuth: { username: 'proxy-user', password: 'proxy-password' } }),
+      song({ sourceServerType: 'navidrome' })
+    );
+    expect(result).toEqual({});
+  });
+});

--- a/src/features/player/mediaHeaders.ts
+++ b/src/features/player/mediaHeaders.ts
@@ -1,0 +1,43 @@
+import type { Server, Song } from '@/types';
+import { plexBasicAuthHeader } from '@/api/plex/client';
+
+/**
+ * The ephemeral request headers a track needs to be fetched, kept off the URL
+ * and off any persisted Song/queue/cache. Audio and artwork are separate
+ * fields because the engine fetches cover art independently of the stream and
+ * wires each to a distinct `Track` field — see `mediaItem.ts` and the engine's
+ * `Track.headers` / `Track.artworkHeaders`.
+ */
+export interface RequestHeaders {
+  headers?: Record<string, string>;
+  artworkHeaders?: Record<string, string>;
+}
+
+const EMPTY: RequestHeaders = {};
+
+/**
+ * Headers for one song against the active server.
+ *
+ * Only a Plex server with Basic auth configured returns anything: those sit
+ * behind a reverse proxy that authenticates every request — the stream and the
+ * artwork alike — with `Authorization: Basic`, and a signed-URL/token provider
+ * (Navidrome, Jellyfin, Emby, a token-only Plex) must be left untouched. The
+ * same header value covers both fetches, but is handed back under the two
+ * distinct fields so the engine wires them independently.
+ *
+ * A song already resolved to a local `file://` path needs no credentials, so
+ * it is skipped even on a Basic-auth Plex server. A song that names a different
+ * provider than the active server (a mixed queue) is likewise skipped — its
+ * credentials are not the ones we hold.
+ */
+export function mediaHeadersForSong(
+  server: Server | null | undefined,
+  song: Pick<Song, 'sourceServerType' | 'streamUrl'>
+): RequestHeaders {
+  if (song.streamUrl?.startsWith('file:')) return EMPTY;
+  const kind = song.sourceServerType ?? server?.type;
+  if (kind !== 'plex') return EMPTY;
+  const auth = plexBasicAuthHeader(server?.basicAuth);
+  if (!auth) return EMPTY;
+  return { headers: auth, artworkHeaders: auth };
+}

--- a/src/features/player/mediaItem.ts
+++ b/src/features/player/mediaItem.ts
@@ -42,6 +42,21 @@ export interface MediaItem {
    * stream endpoints are the case that needs it.
    */
   mimeType?: string;
+  /**
+   * Request headers sent with the *audio* fetch, for a server that
+   * authenticates a stream by header rather than by signing the URL — a Plex
+   * behind a Basic-auth reverse proxy is the concrete case. Ephemeral by
+   * design: attached at playback-resolution time, never persisted on a Song,
+   * a queue snapshot or a cache key, and kept out of the URL query string.
+   */
+  headers?: Record<string, string>;
+  /**
+   * The same idea for the *artwork* fetch. A separate field because the engine
+   * fetches cover art independently of the stream and wires them to two
+   * distinct `Track` fields; for Plex Basic auth both carry the same
+   * Authorization header.
+   */
+  artworkHeaders?: Record<string, string>;
 }
 
 /** What to do when the queue runs out. */

--- a/src/hooks/useCarPlayBrowseTree.ts
+++ b/src/hooks/useCarPlayBrowseTree.ts
@@ -7,6 +7,7 @@ import { useLibrary } from '@/contexts/LibraryContext';
 import { Album, AlbumBase, Playlist, Server, Song, SongBase } from '@/types';
 import { buildCover } from '@/utils/builders/buildCover';
 import { normalizeMediaUrl } from '@/utils/builders/buildTrackItem';
+import { mediaHeadersForSong } from '@/features/player/mediaHeaders';
 import { streamSourceId } from '@/utils/playback/streamId';
 import { QueryKeys } from '@/enums/queryKeys';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
@@ -21,8 +22,9 @@ const CARPLAY_ALBUM_LIMIT = 50;
 const CARPLAY_PLAYLIST_LIMIT = 50;
 const CARPLAY_TRACK_LIMIT = 100;
 
-function toPlayableBrowseItem(song: Song): BrowseItem | null {
+function toPlayableBrowseItem(song: Song, server?: Server | null): BrowseItem | null {
   if (!song.streamUrl) return null;
+  const { headers, artworkHeaders } = mediaHeadersForSong(server, song);
   return {
     mediaId: song.id,
     title: song.title,
@@ -30,6 +32,8 @@ function toPlayableBrowseItem(song: Song): BrowseItem | null {
     artworkUrl: buildCover(song.cover, 'grid') ?? undefined,
     url: normalizeMediaUrl(song.streamUrl),
     duration: Number(song.duration) || undefined,
+    ...(headers ? { headers } : {}),
+    ...(artworkHeaders ? { artworkHeaders } : {}),
   };
 }
 
@@ -205,7 +209,7 @@ export function useCarPlayBrowseTree() {
 
     const favoriteItems = starred
       .slice(0, 100)
-      .map(toPlayableBrowseItem)
+      .map(song => toPlayableBrowseItem(song, activeServer))
       .filter((item): item is BrowseItem => Boolean(item));
     if (favoriteItems.length) {
       categories.push({ mediaId: 'favorites', title: 'Favorites', items: favoriteItems });
@@ -232,7 +236,7 @@ export function useCarPlayBrowseTree() {
           artworkUrl: buildCover(album.cover, 'grid') ?? undefined,
           children: songs
             .slice(0, CARPLAY_TRACK_LIMIT)
-            .map(toPlayableBrowseItem)
+            .map(song => toPlayableBrowseItem(song, activeServer))
             .filter((item): item is BrowseItem => Boolean(item)),
         };
       })
@@ -250,7 +254,7 @@ export function useCarPlayBrowseTree() {
         artworkUrl: buildCover(playlist.cover, 'grid') ?? undefined,
         children: playlist.songs
           .slice(0, CARPLAY_TRACK_LIMIT)
-          .map(toPlayableBrowseItem)
+          .map(song => toPlayableBrowseItem(song, activeServer))
           .filter((item): item is BrowseItem => Boolean(item)),
       }))
       .filter(item => item.children?.length);
@@ -263,5 +267,5 @@ export function useCarPlayBrowseTree() {
     } catch {
       // best-effort
     }
-  }, [activeServer?.id, albums, hydratedPlaylists, queryClient, starred, tracksByAlbumId]);
+  }, [activeServer, albums, hydratedPlaylists, queryClient, starred, tracksByAlbumId]);
 }

--- a/src/utils/builders/buildTrackItem.test.ts
+++ b/src/utils/builders/buildTrackItem.test.ts
@@ -34,4 +34,31 @@ describe('buildTrackItem', () => {
       streamUrl: '/documents/downloads/audio/song-1.mp3',
     }).url).toEqual({ uri: 'file:///documents/downloads/audio/song-1.mp3' });
   });
+
+  it('omits headers and artworkHeaders when none are supplied', () => {
+    const item = buildTrackItem(baseSong);
+    expect(item).not.toHaveProperty('headers');
+    expect(item).not.toHaveProperty('artworkHeaders');
+  });
+
+  it('omits headers and artworkHeaders when the extra carries none', () => {
+    const item = buildTrackItem(baseSong, {});
+    expect(item).not.toHaveProperty('headers');
+    expect(item).not.toHaveProperty('artworkHeaders');
+  });
+
+  it('carries audio and artwork headers through when supplied', () => {
+    const item = buildTrackItem(baseSong, {
+      headers: { Authorization: 'Basic abc' },
+      artworkHeaders: { Authorization: 'Basic abc' },
+    });
+    expect(item.headers).toEqual({ Authorization: 'Basic abc' });
+    expect(item.artworkHeaders).toEqual({ Authorization: 'Basic abc' });
+  });
+
+  it('carries one header field independently of the other', () => {
+    const item = buildTrackItem(baseSong, { headers: { Authorization: 'Basic abc' } });
+    expect(item.headers).toEqual({ Authorization: 'Basic abc' });
+    expect(item).not.toHaveProperty('artworkHeaders');
+  });
 });

--- a/src/utils/builders/buildTrackItem.ts
+++ b/src/utils/builders/buildTrackItem.ts
@@ -1,4 +1,5 @@
 import type { MediaItem } from '../../features/player/mediaItem';
+import type { RequestHeaders } from '../../features/player/mediaHeaders';
 import { Song } from '@/types';
 import { buildCover } from './buildCover';
 
@@ -8,7 +9,15 @@ export function normalizeMediaUrl(url: string): string {
   return url;
 }
 
-export function buildTrackItem(song: Song): MediaItem {
+/**
+ * `extra` carries the ephemeral request headers a protected server needs — a
+ * Plex behind a Basic-auth proxy — resolved by the caller against the active
+ * server (see `mediaHeadersForSong`). Kept a parameter rather than read from
+ * the store here so the builder stays pure and every playback consumer routes
+ * headers through the same resolution point. Fields are set only when present,
+ * so an unprotected server produces exactly the item it did before.
+ */
+export function buildTrackItem(song: Song, extra?: RequestHeaders): MediaItem {
   const url = normalizeMediaUrl(song.streamUrl);
   return {
     mediaId: song.id,
@@ -18,5 +27,7 @@ export function buildTrackItem(song: Song): MediaItem {
     duration: Number(song.duration) || undefined,
     url: url.startsWith('file://') ? { uri: url } : url,
     artworkUrl: buildCover(song.cover, 'grid') ?? undefined,
+    ...(extra?.headers ? { headers: extra.headers } : {}),
+    ...(extra?.artworkHeaders ? { artworkHeaders: extra.artworkHeaders } : {}),
   };
 }


### PR DESCRIPTION
## Summary
Plex servers behind a Basic-auth reverse proxy authenticate every request by header. The app previously dropped that header on the direct audio stream and the artwork fetch, so protected Plex playback and cover art failed. This wires request headers from the app model through to the engine (yuzic-engine 1.0.5) for **both** audio (`Track.headers`) and now-playing artwork (`Track.artworkHeaders`).

- Headers are attached at playback-resolution time and **never persisted** on a Song, queue snapshot, cache key, or URL query string.
- Only a Plex server with `basicAuth` set is affected. Token/signed-URL providers (Navidrome, Jellyfin, Emby, token-only Plex) produce byte-identical items to before.
- Single choke point: `PlayingContext` resolves headers via `mediaHeadersForSong(activeServer, song)`, so every consumer (foreground play, queue add, autoplay fill, play-next, restore) routes through one point.
- Consumers verified: foreground/queue/autoplay/play-next/restore, CarPlay/Android Auto browse (now-playing art), and downloads (Expo resumable session headers).
- URL-only DLNA casting is **capability-gated**: a header-authenticated track is not cast as a bare URL that would 401 silently.

## Known limitation
The browse-list thumbnail (`BrowseNode.artworkUrl`) has no header-carrying field in the engine, so protected-server browse-tile thumbnails may not render. Now-playing artwork is unaffected. Documented in `browse.ts`.

## Validation
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors, 52 pre-existing warnings
- `npx jest --ci` — 112 suites / 995 tests (added 20: buildTrackItem, engineBackend round-trip, and mediaHeaders scenarios covering Basic-auth Plex vs token-only Plex vs Navidrome)

Bumps `yuzic-engine` to `^1.0.5`. No app version change; not a release PR.