### PR TITLE
Release 2.3.0

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,6 +1,7 @@
-Original-quality FLAC playback, account pictures, and a more reliable player.
+Plex support, protected artwork, easier local imports, and connection fixes.
 
-- iOS now plays FLAC streams at original quality
-- Your account picture appears throughout the app
-- Fixed a player drag that could leave the mini player hidden
-- Refreshed the project gallery and simplified its README
+- Play from Plex servers, including those behind a Basic-auth reverse proxy
+- Lock-screen and Now Playing artwork now loads from authenticated servers
+- Import local audio files any time from Settings > Library
+- Fixed signing in to Jellyfin 12 servers
+- Complete Plex libraries with correct pagination across albums and playlists

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yuzic",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yuzic",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@backpackapp-io/react-native-toast": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yuzic",
   "main": "expo-router/entry",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
Version bump to 2.3.0 + Play changelog. Merges onto dev; the release fires from the subsequent dev->master PR.