### PR TITLE
Phase D — Feature-oriented settings (library-intent)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -413,6 +413,44 @@ acquiring. The two are deliberately different code paths.
   surfacing all activity a provider reports including jobs started outside yuzic,
   reading the single shared `useDownloadersQueue` poll.
 
+## 9. Feature-oriented settings — configure the goal, not the provider
+
+Settings pages are organized by what the user wants yuzic to *do*, not by which
+integration supplies it. `screens/settings/home/` set the precedent (pulling
+Home-affecting toggles out of the per-integration screens); Scrobbling, Lyrics,
+Metadata, and Search follow it. Each reuses the `SettingsScreen` shell and is a
+route leaf registered in `settings/_layout.tsx` with a row on the settings root.
+
+- **Scrobbling** (`screens/settings/scrobbling/`) — exactly one route *per
+  destination, per server*: `disabled | through-server | direct`, stored in
+  `settingsSlice.scrobbleRoutes[serverId]`. The single enum per destination makes
+  "at most one route" structural (no double-scrobble). Defaults are *derived at
+  read time* from the pre-existing booleans (`deriveScrobbleRoute`), so no
+  migration runs. **Last.fm offers only disabled/through-server** this cut
+  (direct needs a signed session — sequenced out). `useScrobbling` routes by the
+  enum; a duplicate-risk note shows on `through-server` (yuzic can't verify
+  server forwarding).
+- **Lyrics** (`screens/settings/lyrics/`, `features/lyrics/resolveLyrics.ts`) —
+  server-embedded first, then user-ordered external sources; `resolveLyrics`
+  returns the first non-empty result. **LRCLIB** (`api/lrclib/`) is the launch
+  external source: `none`-tier, no key, *one* source that prefers synced and
+  falls back to plain internally. Off by default → server-only behaviour is
+  unchanged until a user enables it.
+- **Metadata** (`screens/settings/metadata/`, `features/metadata/`) — independent
+  **Artist-information** and **Artwork** controls, each its own ordered
+  enabled-source chain (`resolveArtistInfo`, `resolveArtwork`). **Display-only and
+  gaps-only**: the resolvers never write to any server and only fill a field the
+  server left empty, so disabling instantly restores the server view. Launch
+  sources: Last.fm `artist.getInfo`; Deezer artist images + Cover Art Archive
+  covers. A small "via X" line, never per-item badges.
+- **Search** (`screens/settings/search/`, `contexts/searchLegs.ts`) — a segmented
+  **Your Library** (default, no external calls) / **Other sources** scope with a
+  Filters sheet for search-enabled sources and entity types. `planSearchLegs`
+  picks library **XOR** external by scope, so results are never mixed by default;
+  provenance is preserved and editions/ambiguous matches stay separate.
+  `searchSourcesEnabled` is independent of Home enablement (legacy
+  `deezerSearchEnabled` reconciled at read time, no migration).
+
 ## Where things live
 
 ```

--- a/src/api/lastfm/getArtistInfo.test.ts
+++ b/src/api/lastfm/getArtistInfo.test.ts
@@ -1,0 +1,62 @@
+import { getLastFmArtistInfo } from './getArtistInfo';
+import { lastfmRequest } from './client';
+
+jest.mock('./client', () => ({
+  lastfmRequest: jest.fn(),
+}));
+
+const mockedLastfmRequest = lastfmRequest as jest.Mock;
+
+describe('getLastFmArtistInfo', () => {
+  beforeEach(() => {
+    mockedLastfmRequest.mockReset();
+  });
+
+  it('parses bio and tags out of the artist.getinfo response', async () => {
+    mockedLastfmRequest.mockResolvedValue({
+      artist: {
+        bio: { summary: 'An English rock band. <a href="https://last.fm/x">Read more on Last.fm</a>' },
+        tags: { tag: [{ name: 'alternative' }, { name: 'rock' }] },
+      },
+    });
+
+    const result = await getLastFmArtistInfo('key', 'Radiohead');
+
+    expect(result).toEqual({ bio: 'An English rock band.', tags: ['alternative', 'rock'] });
+    expect(mockedLastfmRequest).toHaveBeenCalledWith(
+      { method: 'artist.getinfo', artist: 'Radiohead', autocorrect: '1' },
+      { apiKey: 'key' }
+    );
+  });
+
+  it('returns null with no api key', async () => {
+    const result = await getLastFmArtistInfo('', 'Radiohead');
+    expect(result).toBeNull();
+    expect(mockedLastfmRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns null with a blank artist name', async () => {
+    const result = await getLastFmArtistInfo('key', '   ');
+    expect(result).toBeNull();
+    expect(mockedLastfmRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the response has neither bio nor tags', async () => {
+    mockedLastfmRequest.mockResolvedValue({ artist: { bio: { summary: '' }, tags: { tag: [] } } });
+
+    const result = await getLastFmArtistInfo('key', 'Radiohead');
+    expect(result).toBeNull();
+  });
+
+  it('returns a result with tags only when bio is missing', async () => {
+    mockedLastfmRequest.mockResolvedValue({ artist: { tags: { tag: [{ name: 'jazz' }] } } });
+
+    const result = await getLastFmArtistInfo('key', 'Miles Davis');
+    expect(result).toEqual({ bio: null, tags: ['jazz'] });
+  });
+
+  it('propagates errors from lastfmRequest', async () => {
+    mockedLastfmRequest.mockRejectedValue(new Error('boom'));
+    await expect(getLastFmArtistInfo('key', 'Radiohead')).rejects.toThrow('boom');
+  });
+});

--- a/src/api/lastfm/getArtistInfo.ts
+++ b/src/api/lastfm/getArtistInfo.ts
@@ -1,0 +1,53 @@
+import { lastfmRequest } from './client';
+
+export type LastFmArtistInfo = {
+  bio: string | null;
+  tags: string[];
+};
+
+// artist.getinfo is a public read like artist.getsimilar — no session or
+// api_sig needed, just the bundled api_key. Used for display-only bio/tag
+// gap-filling (see features/metadata) — never written back to any server.
+export async function getLastFmArtistInfo(
+  apiKey: string,
+  artistName: string
+): Promise<LastFmArtistInfo | null> {
+  if (!apiKey || !artistName.trim()) return null;
+  try {
+    const data = await lastfmRequest<{
+      artist?: {
+        bio?: { summary?: string; content?: string };
+        tags?: { tag?: { name?: string }[] };
+      };
+    }>(
+      {
+        method: 'artist.getinfo',
+        artist: artistName,
+        autocorrect: '1',
+      },
+      { apiKey }
+    );
+
+    const artist = data.artist;
+    if (!artist) return null;
+
+    // Last.fm's summary carries an embedded "Read more on Last.fm" link;
+    // strip the trailing <a href=...>...</a> so the bio reads as plain text.
+    const rawBio = artist.bio?.summary ?? artist.bio?.content ?? '';
+    const bio = rawBio.replace(/<a\s+href="[^"]*">[^<]*<\/a>/gi, '').trim();
+
+    const tags = (artist.tags?.tag ?? [])
+      .map(tag => tag.name?.trim())
+      .filter((name): name is string => !!name);
+
+    if (!bio && tags.length === 0) return null;
+
+    return {
+      bio: bio || null,
+      tags,
+    };
+  } catch (error) {
+    console.error('Last.fm getArtistInfo failed:', error);
+    throw error;
+  }
+}

--- a/src/api/lastfm/index.ts
+++ b/src/api/lastfm/index.ts
@@ -1,2 +1,4 @@
 export { getLastFmSimilarArtists } from './getSimilarArtists'
 export type { LastFmSimilarArtist } from './getSimilarArtists'
+export { getLastFmArtistInfo } from './getArtistInfo'
+export type { LastFmArtistInfo } from './getArtistInfo'

--- a/src/api/lrclib/getLyrics.test.ts
+++ b/src/api/lrclib/getLyrics.test.ts
@@ -1,0 +1,106 @@
+import { getLyrics } from "./getLyrics";
+import { fetchWithTimeout } from "@/api/fetchWithTimeout";
+
+jest.mock("@/api/fetchWithTimeout", () => ({
+  fetchWithTimeout: jest.fn(),
+}));
+
+const mockedFetch = fetchWithTimeout as jest.Mock;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe("lrclib getLyrics", () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it("prefers synced lyrics, parsed into timed lines", async () => {
+    mockedFetch.mockResolvedValue(
+      jsonResponse({
+        syncedLyrics: "[00:00.00] hello\n[00:01.50] world",
+        plainLyrics: "hello\nworld",
+      })
+    );
+
+    const result = await getLyrics({ artist: "A", title: "T" });
+
+    expect(result).toEqual({
+      provider: "lrclib",
+      synced: true,
+      lines: [
+        { startMs: 0, text: "hello" },
+        { startMs: 1500, text: "world" },
+      ],
+    });
+  });
+
+  it("falls back to plain lyrics when nothing is synced", async () => {
+    mockedFetch.mockResolvedValue(
+      jsonResponse({ syncedLyrics: null, plainLyrics: "line one\nline two" })
+    );
+
+    const result = await getLyrics({ artist: "A", title: "T" });
+
+    expect(result).toEqual({
+      provider: "lrclib",
+      synced: false,
+      lines: [
+        { startMs: 0, text: "line one" },
+        { startMs: 0, text: "line two" },
+      ],
+    });
+  });
+
+  it("returns null on a 404 (no match)", async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({}, 404));
+
+    const result = await getLyrics({ artist: "A", title: "T" });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null for an instrumental track", async () => {
+    mockedFetch.mockResolvedValue(
+      jsonResponse({ instrumental: true, plainLyrics: "should be ignored" })
+    );
+
+    const result = await getLyrics({ artist: "A", title: "T" });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when both lyric fields are empty", async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({ syncedLyrics: "", plainLyrics: "" }));
+
+    const result = await getLyrics({ artist: "A", title: "T" });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null instead of throwing on a network failure", async () => {
+    mockedFetch.mockRejectedValue(new Error("network down"));
+
+    const result = await getLyrics({ artist: "A", title: "T" });
+
+    expect(result).toBeNull();
+  });
+
+  it("sends a real User-Agent and the optional query params", async () => {
+    mockedFetch.mockResolvedValue(jsonResponse({ plainLyrics: "x" }));
+
+    await getLyrics({ artist: "A", title: "T", album: "Alb", durationSec: 180.4 });
+
+    const [url, init] = mockedFetch.mock.calls[0];
+    expect(url).toContain("artist_name=A");
+    expect(url).toContain("track_name=T");
+    expect(url).toContain("album_name=Alb");
+    expect(url).toContain("duration=180");
+    expect(init.headers["User-Agent"]).toEqual(expect.stringContaining("yuzic"));
+  });
+});

--- a/src/api/lrclib/getLyrics.ts
+++ b/src/api/lrclib/getLyrics.ts
@@ -1,0 +1,99 @@
+import type { LyricsResult } from "@/api/types";
+import { fetchWithTimeout } from "@/api/fetchWithTimeout";
+import { parseLrc } from "./parseLrc";
+
+const BASE = "https://lrclib.net/api";
+// LRCLIB is a none-tier source: no key, no account. It only asks that
+// clients identify themselves with a real User-Agent, which this satisfies
+// without needing any credential the user would have to go get.
+const HEADERS = {
+  "User-Agent": "yuzic (https://github.com/yuzicapp/yuzic)",
+  Accept: "application/json",
+};
+
+export type GetLyricsInput = {
+  artist: string;
+  title: string;
+  album?: string;
+  durationSec?: number;
+};
+
+type LrclibGetResponse = {
+  id?: number;
+  trackName?: string;
+  artistName?: string;
+  albumName?: string;
+  duration?: number;
+  instrumental?: boolean;
+  plainLyrics?: string | null;
+  syncedLyrics?: string | null;
+};
+
+/**
+ * Turns an LRCLIB `/api/get` response into the app's `LyricsResult`, or null
+ * when the track has no usable lyrics.
+ *
+ * LRCLIB is modelled as ONE source, not two: it prefers `syncedLyrics` and
+ * only falls back to `plainLyrics` internally when nothing synced exists.
+ * There is no separate "LRCLIB (plain)" fallback link for callers to
+ * configure — that distinction lives inside this function.
+ */
+function toLyricsResult(data: LrclibGetResponse): LyricsResult | null {
+  if (data.syncedLyrics && data.syncedLyrics.trim()) {
+    const lines = parseLrc(data.syncedLyrics);
+    if (lines.length > 0) {
+      return { provider: "lrclib", synced: true, lines };
+    }
+  }
+
+  if (data.plainLyrics && data.plainLyrics.trim()) {
+    const lines = data.plainLyrics
+      .split(/\r?\n/)
+      .map(text => text.trim())
+      .filter(text => text.length > 0)
+      .map(text => ({ startMs: 0, text }));
+    if (lines.length > 0) {
+      return { provider: "lrclib", synced: false, lines };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Looks up lyrics on LRCLIB (https://lrclib.net) for one track.
+ *
+ * Anonymous, no API key, no account — the "none" auth tier. Returns null on
+ * a 404 (LRCLIB's answer for "no match"), on an empty/instrumental result,
+ * or on any network failure, so a caller can treat this the same way as
+ * "no lyrics" rather than needing a separate error path.
+ */
+export async function getLyrics(input: GetLyricsInput): Promise<LyricsResult | null> {
+  const params = new URLSearchParams({
+    artist_name: input.artist,
+    track_name: input.title,
+  });
+  if (input.album) params.set("album_name", input.album);
+  if (typeof input.durationSec === "number" && input.durationSec > 0) {
+    params.set("duration", String(Math.round(input.durationSec)));
+  }
+
+  try {
+    const res = await fetchWithTimeout(`${BASE}/get?${params.toString()}`, {
+      headers: HEADERS,
+    });
+
+    if (res.status === 404) return null;
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as LrclibGetResponse;
+    if (data.instrumental) return null;
+
+    return toLyricsResult(data);
+  } catch {
+    // LRCLIB being unreachable is the same as it having nothing — an
+    // external fallback source failing silently is what lets the fallback
+    // chain move on to the next source (or to nothing) without throwing.
+    return null;
+  }
+}

--- a/src/api/lrclib/index.ts
+++ b/src/api/lrclib/index.ts
@@ -1,0 +1,3 @@
+export { getLyrics } from "./getLyrics";
+export type { GetLyricsInput } from "./getLyrics";
+export { parseLrc } from "./parseLrc";

--- a/src/api/lrclib/parseLrc.test.ts
+++ b/src/api/lrclib/parseLrc.test.ts
@@ -1,0 +1,51 @@
+import { parseLrc } from "./parseLrc";
+
+describe("parseLrc", () => {
+  it("parses [mm:ss.xx] timestamps into startMs", () => {
+    const lrc = "[00:00.00] first\n[00:04.20] second";
+
+    expect(parseLrc(lrc)).toEqual([
+      { startMs: 0, text: "first" },
+      { startMs: 4200, text: "second" },
+    ]);
+  });
+
+  it("parses centisecond and millisecond fractions correctly", () => {
+    const lrc = "[01:02.5] a\n[00:01.123] b";
+
+    // Sorted by timestamp — "b" at ~1.1s comes before "a" at ~62.5s.
+    expect(parseLrc(lrc)).toEqual([
+      { startMs: 1_123, text: "b" },
+      // .5 as a 1-digit fraction pads to 500ms
+      { startMs: 62_500, text: "a" },
+    ]);
+  });
+
+  it("supports multiple timestamps sharing one line of text", () => {
+    const lrc = "[00:01.00][00:05.00] repeated";
+
+    expect(parseLrc(lrc)).toEqual([
+      { startMs: 1000, text: "repeated" },
+      { startMs: 5000, text: "repeated" },
+    ]);
+  });
+
+  it("skips metadata tags and blank/untimed lines", () => {
+    const lrc = "[ar:Some Artist]\n[ti:Some Title]\n\n[00:00.00]\n[00:02.00] real line";
+
+    expect(parseLrc(lrc)).toEqual([{ startMs: 2000, text: "real line" }]);
+  });
+
+  it("sorts lines by timestamp even if the source is out of order", () => {
+    const lrc = "[00:05.00] later\n[00:01.00] earlier";
+
+    expect(parseLrc(lrc)).toEqual([
+      { startMs: 1000, text: "earlier" },
+      { startMs: 5000, text: "later" },
+    ]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(parseLrc("")).toEqual([]);
+  });
+});

--- a/src/api/lrclib/parseLrc.ts
+++ b/src/api/lrclib/parseLrc.ts
@@ -1,0 +1,37 @@
+import type { LyricLine } from "@/api/types";
+
+/**
+ * Parses LRC-format synced lyrics (`[mm:ss.xx] text`, one line at a time)
+ * into the app's `LyricLine[]` shape.
+ *
+ * LRCLIB (and LRC generally) allows more than one timestamp per line
+ * (`[00:01.00][00:05.00] text`) and metadata tags (`[ar:...]`, `[ti:...]`)
+ * that carry no timestamp at all — both are skipped rather than treated as
+ * lyric lines, since a metadata tag rendered as a lyric would read as a
+ * blank or garbled line in the sheet.
+ */
+export function parseLrc(lrc: string): LyricLine[] {
+  const lines: LyricLine[] = [];
+  const timeTag = /\[(\d{1,2}):(\d{2})(?:[.:](\d{1,3}))?\]/g;
+
+  for (const rawLine of lrc.split(/\r?\n/)) {
+    const tags = [...rawLine.matchAll(timeTag)];
+    if (tags.length === 0) continue;
+
+    const text = rawLine.replace(timeTag, "").trim();
+    if (!text) continue;
+
+    for (const tag of tags) {
+      const minutes = Number(tag[1]);
+      const seconds = Number(tag[2]);
+      const fraction = tag[3] ?? "0";
+      // A 2-digit fraction is centiseconds, a 3-digit one is milliseconds —
+      // pad/truncate to milliseconds either way.
+      const ms = Number(fraction.padEnd(3, "0").slice(0, 3));
+      const startMs = Math.round(minutes * 60_000 + seconds * 1000 + ms);
+      lines.push({ startMs, text });
+    }
+  }
+
+  return lines.sort((a, b) => a.startMs - b.startMs);
+}

--- a/src/api/musicbrainz/index.ts
+++ b/src/api/musicbrainz/index.ts
@@ -66,6 +66,24 @@ export async function searchReleaseGroup(
   return data['release-groups'] ?? [];
 }
 
+/**
+ * Free-text release-group search, keyed on title alone rather than an
+ * artist+title pair — this is what search's "Other sources" scope wants
+ * (a user typing an album name with no artist context yet), whereas
+ * {@link searchReleaseGroup} is for resolving a specific artist's album.
+ */
+export async function searchReleaseGroupByTitle(
+  query: string,
+  limit = 5
+): Promise<MbReleaseGroup[]> {
+  if (!query.trim()) return [];
+  const q = encodeURIComponent(`releasegroup:"${query}"`);
+  const data = await mb<{ 'release-groups': MbReleaseGroup[] }>(
+    `/release-group?query=${q}&limit=${limit}&fmt=json`
+  );
+  return data['release-groups'] ?? [];
+}
+
 export async function getArtistWithReleases(mbid: string): Promise<MbArtist> {
   return mb<MbArtist>(`/artist/${mbid}?inc=release-groups&fmt=json`);
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -352,7 +352,13 @@ export type LyricLine = {
 };
 
 export type LyricsResult = {
-  provider: "jellyfin" | "navidrome" | "emby";
+  /**
+   * `"lrclib"` is not a server type: it is the one launch entry in the
+   * user-configurable external fallback chain (see
+   * `features/lyrics/resolveLyrics`), which only ever runs after the
+   * server-embedded lookup below has come back empty.
+   */
+  provider: "jellyfin" | "navidrome" | "emby" | "lrclib";
   /**
    * Whether `startMs` on each line means anything.
    *

--- a/src/app/(home)/(tabs)/(home,search,library)/settings/_layout.tsx
+++ b/src/app/(home)/(tabs)/(home,search,library)/settings/_layout.tsx
@@ -15,10 +15,12 @@ export default function SettingsLayout() {
             <Stack.Screen name='slskdView' options={{ headerShown: false, title: "slskd" }} />
             <Stack.Screen name='soulsyncView' options={{ headerShown: false, title: "SoulSync" }} />
             <Stack.Screen name='listenbrainzView' options={{ headerShown: false, title: "ListenBrainz" }} />
+            <Stack.Screen name='scrobblingView' options={{ headerShown: false, title: "Scrobbling" }} />
             <Stack.Screen name='deezerView' options={{ headerShown: false, title: "Deezer" }} />
             <Stack.Screen name='lastfmView' options={{ headerShown: false, title: "Last.fm" }} />
             <Stack.Screen name='musicbrainzView' options={{ headerShown: false, title: "MusicBrainz" }} />
             <Stack.Screen name='audiomuseView' options={{ headerShown: false, title: "AudioMuse-AI" }} />
+            <Stack.Screen name='lyricsView' options={{ headerShown: false, title: "Lyrics" }} />
         </Stack>
     );
 }

--- a/src/app/(home)/(tabs)/(home,search,library)/settings/_layout.tsx
+++ b/src/app/(home)/(tabs)/(home,search,library)/settings/_layout.tsx
@@ -21,6 +21,8 @@ export default function SettingsLayout() {
             <Stack.Screen name='musicbrainzView' options={{ headerShown: false, title: "MusicBrainz" }} />
             <Stack.Screen name='audiomuseView' options={{ headerShown: false, title: "AudioMuse-AI" }} />
             <Stack.Screen name='lyricsView' options={{ headerShown: false, title: "Lyrics" }} />
+            <Stack.Screen name='searchView' options={{ headerShown: false, title: "Search" }} />
+            <Stack.Screen name='metadataView' options={{ headerShown: false, title: "Metadata" }} />
         </Stack>
     );
 }

--- a/src/app/(home)/(tabs)/(home,search,library)/settings/lyricsView.tsx
+++ b/src/app/(home)/(tabs)/(home,search,library)/settings/lyricsView.tsx
@@ -1,0 +1,5 @@
+import LyricsSettings from "@/screens/settings/lyrics";
+
+export default function LyricsSettingsScreen() {
+  return <LyricsSettings />;
+}

--- a/src/app/(home)/(tabs)/(home,search,library)/settings/metadataView.tsx
+++ b/src/app/(home)/(tabs)/(home,search,library)/settings/metadataView.tsx
@@ -1,0 +1,5 @@
+import MetadataSettings from "@/screens/settings/metadata";
+
+export default function MetadataSettingsScreen() {
+  return <MetadataSettings />;
+}

--- a/src/app/(home)/(tabs)/(home,search,library)/settings/scrobblingView.tsx
+++ b/src/app/(home)/(tabs)/(home,search,library)/settings/scrobblingView.tsx
@@ -1,0 +1,5 @@
+import ScrobblingSettings from "@/screens/settings/scrobbling";
+
+export default function ScrobblingSettingsScreen() {
+  return <ScrobblingSettings />;
+}

--- a/src/app/(home)/(tabs)/(home,search,library)/settings/searchView.tsx
+++ b/src/app/(home)/(tabs)/(home,search,library)/settings/searchView.tsx
@@ -1,0 +1,5 @@
+import SearchSettings from "@/screens/settings/search";
+
+export default function SearchSettingsScreen() {
+  return <SearchSettings />;
+}

--- a/src/components/options/OptionSheetPrimitives.tsx
+++ b/src/components/options/OptionSheetPrimitives.tsx
@@ -55,6 +55,7 @@ type RowProps = {
   loading?: boolean;
   labelColor?: string;
   trailing?: React.ReactNode;
+  testID?: string;
 };
 
 export function OptionSheetRow({
@@ -68,12 +69,14 @@ export function OptionSheetRow({
   loading,
   labelColor,
   trailing,
+  testID,
 }: RowProps) {
   const { colors } = useTheme();
   const leading = loading ? <SpinningLoaderCircle size={iconSize.row} color={colors.subtext} /> : icon;
 
   return (
     <Touchable
+      testID={testID}
       style={[styles.option, dimRow && styles.optionDimmed]}
       onPress={onPress}
       disabled={disabled || !onPress}

--- a/src/contexts/SearchContext.test.tsx
+++ b/src/contexts/SearchContext.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { SearchProvider, useSearch } from './SearchContext';
+
+// Library data hooks — enough of a shape for SearchContext to build its
+// lowercased search index over.
+jest.mock('@/hooks/albums', () => ({
+  useAlbums: () => ({ albums: [] }),
+}));
+jest.mock('@/hooks/artists', () => ({
+  useArtists: () => ({ artists: [] }),
+}));
+jest.mock('@/hooks/playlists', () => ({
+  usePlaylists: () => ({ playlists: [] }),
+}));
+jest.mock('@/hooks/tracks', () => ({
+  useTracks: () => ({ tracks: [] }),
+}));
+
+jest.mock('@/api', () => ({
+  useApi: () => ({ search: { search: jest.fn().mockResolvedValue({ albums: [], artists: [], songs: [] }) } }),
+}));
+
+jest.mock('@/contexts/DownloadContext', () => ({
+  useDownload: () => ({
+    downloadedTracks: [],
+    getAllDownloadedCollections: () => [],
+  }),
+}));
+
+let mockIsOffline = false;
+jest.mock('@/hooks/useIsOffline', () => ({
+  useIsOffline: () => mockIsOffline,
+}));
+
+let mockServerUnreachable = false;
+jest.mock('@/features/connectivity/serverReachability', () => ({
+  useServerUnreachable: () => mockServerUnreachable,
+}));
+
+const mockSearchDeezerArtists = jest.fn().mockResolvedValue([]);
+const mockSearchDeezerAlbums = jest.fn().mockResolvedValue([
+  { id: 'dz-1', title: 'Rumours', subtext: '1977', artist: 'Fleetwood Mac', cover: { kind: 'none' }, externalSource: 'deezer', externalIds: { deezerId: 'dz-1' } },
+]);
+jest.mock('@/api/deezer', () => ({
+  searchDeezerArtists: (...args: unknown[]) => mockSearchDeezerArtists(...args),
+  searchDeezerAlbums: (...args: unknown[]) => mockSearchDeezerAlbums(...args),
+}));
+
+const mockSearchArtist = jest.fn().mockResolvedValue([]);
+const mockSearchReleaseGroupByTitle = jest.fn().mockResolvedValue([
+  { id: 'mb-1', title: 'Rumours', 'first-release-date': '1977-02-04' },
+]);
+jest.mock('@/api/musicbrainz', () => ({
+  searchArtist: (...args: unknown[]) => mockSearchArtist(...args),
+  searchReleaseGroupByTitle: (...args: unknown[]) => mockSearchReleaseGroupByTitle(...args),
+}));
+
+let mockSearchScope: 'client' | 'server' = 'server';
+jest.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector({
+    settings: { searchScope: mockSearchScope },
+  }),
+}));
+jest.mock('@/utils/redux/selectors/settingsSelectors', () => ({
+  selectSearchScope: (s: { settings: { searchScope: string } }) => s.settings.searchScope,
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <SearchProvider>{children}</SearchProvider>;
+}
+
+describe('SearchContext handleSearchWithFilters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsOffline = false;
+    mockServerUnreachable = false;
+    mockSearchDeezerArtists.mockResolvedValue([]);
+    mockSearchDeezerAlbums.mockResolvedValue([
+      { id: 'dz-1', title: 'Rumours', subtext: '1977', artist: 'Fleetwood Mac', cover: { kind: 'none' }, externalSource: 'deezer', externalIds: { deezerId: 'dz-1' } },
+    ]);
+    mockSearchArtist.mockResolvedValue([]);
+    mockSearchReleaseGroupByTitle.mockResolvedValue([
+      { id: 'mb-1', title: 'Rumours', 'first-release-date': '1977-02-04' },
+    ]);
+  });
+
+  it('never calls an external source for the default library scope', async () => {
+    const { result } = await renderHook(() => useSearch(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleSearchWithFilters('rumours', {
+        resultScope: 'library',
+        sourceIds: ['deezer'],
+      });
+    });
+
+    expect(mockSearchDeezerAlbums).not.toHaveBeenCalled();
+    expect(mockSearchReleaseGroupByTitle).not.toHaveBeenCalled();
+    // Only the library/server leg's results, never external ones.
+    expect(result.current.searchResults.every(r => r.source === 'local')).toBe(true);
+  });
+
+  it('queries the enabled source when scope is "other"', async () => {
+    const { result } = await renderHook(() => useSearch(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleSearchWithFilters('rumours', {
+        resultScope: 'other',
+        sourceIds: ['deezer'],
+      });
+    });
+
+    expect(mockSearchDeezerAlbums).toHaveBeenCalledWith('rumours', 6);
+    expect(mockSearchReleaseGroupByTitle).not.toHaveBeenCalled();
+  });
+
+  it('never mixes library and external results in one response', async () => {
+    const { result } = await renderHook(() => useSearch(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleSearchWithFilters('rumours', {
+        resultScope: 'other',
+        sourceIds: ['deezer'],
+      });
+    });
+
+    expect(result.current.searchResults.length).toBeGreaterThan(0);
+    expect(result.current.searchResults.every(r => r.source === 'external')).toBe(true);
+  });
+
+  it('preserves provenance per source and keeps editions from different sources separate', async () => {
+    const { result } = await renderHook(() => useSearch(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleSearchWithFilters('rumours', {
+        resultScope: 'other',
+        sourceIds: ['deezer', 'musicbrainz'],
+      });
+    });
+
+    const sources = result.current.searchResults.map(r => r.externalSource);
+    expect(sources).toContain('deezer');
+    expect(sources).toContain('musicbrainz');
+    // Two distinct records for the same album title, one per source — not
+    // collapsed into a single merged row.
+    expect(result.current.searchResults.filter(r => r.type === 'album')).toHaveLength(2);
+  });
+
+  it("the Filters selection limits which sources are queried", async () => {
+    const { result } = await renderHook(() => useSearch(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleSearchWithFilters('rumours', {
+        resultScope: 'other',
+        sourceIds: ['musicbrainz'],
+      });
+    });
+
+    expect(mockSearchDeezerAlbums).not.toHaveBeenCalled();
+    expect(mockSearchReleaseGroupByTitle).toHaveBeenCalled();
+  });
+
+  it('the Filters entity-type selection limits which entity types are asked for', async () => {
+    const { result } = await renderHook(() => useSearch(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleSearchWithFilters('rumours', {
+        resultScope: 'other',
+        sourceIds: ['deezer'],
+        entityTypes: ['artist'],
+      });
+    });
+
+    expect(mockSearchDeezerAlbums).not.toHaveBeenCalled();
+  });
+
+  it('marks external results as degraded rather than errored when offline', async () => {
+    mockIsOffline = true;
+    const { result } = await renderHook(() => useSearch(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleSearchWithFilters('rumours', {
+        resultScope: 'other',
+        sourceIds: ['deezer'],
+      });
+    });
+
+    expect(mockSearchDeezerAlbums).not.toHaveBeenCalled();
+    expect(result.current.degraded).toBe(true);
+    expect(result.current.hasError).toBe(false);
+  });
+
+  it('does nothing for an empty query', async () => {
+    const { result } = await renderHook(() => useSearch(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleSearchWithFilters('   ', {
+        resultScope: 'other',
+        sourceIds: ['deezer'],
+      });
+    });
+
+    expect(mockSearchDeezerAlbums).not.toHaveBeenCalled();
+    expect(result.current.searchResults).toEqual([]);
+  });
+
+  it('falls back to the local index for the library scope when the server is unreachable', async () => {
+    mockServerUnreachable = true;
+    mockSearchScope = 'server';
+    const { result } = await renderHook(() => useSearch(), { wrapper });
+
+    await act(async () => {
+      await result.current.handleSearchWithFilters('rumours', {
+        resultScope: 'library',
+        sourceIds: [],
+      });
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.degraded).toBe(true);
+  });
+});

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/types';
 
 import * as deezer from '@/api/deezer';
+import * as mb from '@/api/musicbrainz';
 import { useAlbums } from '@/hooks/albums';
 import { useArtists } from '@/hooks/artists';
 import { usePlaylists } from '@/hooks/playlists';
@@ -35,19 +36,39 @@ import {
 } from '@/utils/downloads/collectionState';
 
 import { dedupeAndSort, type SearchResult } from './searchRanking';
-import { planSearchLegs } from './searchLegs';
+import { planSearchLegs, type SearchResultScope } from './searchLegs';
 
 export type { SearchResult } from './searchRanking';
+export type { SearchResultScope } from './searchLegs';
+
+/** Entity types an external source can be asked to return. Deliberately
+ *  narrower than the library's four kinds — 'song'/'playlist' have no
+ *  external equivalent through Deezer/MusicBrainz today, so filtering on
+ *  them would just always empty out; the Filters UI only offers what a
+ *  source actually supports. */
+export type SearchEntityType = 'album' | 'artist';
+
+export const ALL_SEARCH_ENTITY_TYPES: SearchEntityType[] = ['album', 'artist'];
 
 export type SearchFilters = {
-  local: boolean;
-  deezer: boolean;
-}
+  /** 'library' (default) — today's local search — or 'other', the
+   *  deliberate external-search action. The two are never both attempted
+   *  in the same request; that split is what keeps library and external
+   *  results from mixing by default. */
+  resultScope: SearchResultScope;
+  /** Source ids to query when `resultScope` is 'other' — the sources the
+   *  Filters sheet left checked, already narrowed to ones enabled for
+   *  search. Ignored when `resultScope` is 'library'. */
+  sourceIds: string[];
+  /** Which entity types to ask each external source for. Defaults to all
+   *  supported types when omitted. Ignored when `resultScope` is 'library'. */
+  entityTypes?: SearchEntityType[];
+};
 
 interface SearchContextType {
   searchResults: SearchResult[];
   searchLibrary: (query: string) => Promise<SearchResult[]>;
-  searchExternal: (query: string) => Promise<SearchResult[]>;
+  searchExternal: (query: string, sourceIds: string[], entityTypes: SearchEntityType[]) => Promise<SearchResult[]>;
   clearSearch: () => void;
   isLoading: boolean;
   /** True when the most recent search failed to reach the server/external source, so results shown (if any) may be incomplete. */
@@ -146,6 +167,59 @@ function playlistToResult(playlist: PlaylistBase, isDownloaded: boolean): Search
   };
 }
 
+/**
+ * One external source's contribution to a search, kept provenance-tagged
+ * (`externalSource` on every result) rather than merged with any other
+ * source's results — see the module doc on `searchExternal` for why.
+ */
+async function searchExternalSource(
+  sourceId: string,
+  query: string,
+  entityTypes: SearchEntityType[]
+): Promise<SearchResult[]> {
+  const wantsArtists = entityTypes.includes('artist');
+  const wantsAlbums = entityTypes.includes('album');
+
+  if (sourceId === 'deezer') {
+    const [artists, albums] = await Promise.all([
+      wantsArtists ? deezer.searchDeezerArtists(query, 4) : Promise.resolve([]),
+      wantsAlbums ? deezer.searchDeezerAlbums(query, 6) : Promise.resolve([]),
+    ]);
+    return [
+      ...artists.map(artist => artistToResult(artist, false, 'external')),
+      ...albums.map(album => albumToResult(album, 'external', false)),
+    ];
+  }
+
+  if (sourceId === 'musicbrainz') {
+    const [artists, releaseGroups] = await Promise.all([
+      wantsArtists ? mb.searchArtist(query, 4) : Promise.resolve([]),
+      wantsAlbums ? mb.searchReleaseGroupByTitle(query, 6) : Promise.resolve([]),
+    ]);
+    return [
+      ...artists.map(artist => artistToResult(
+        { id: artist.id, name: artist.name, subtext: '', cover: { kind: 'none' }, externalSource: 'musicbrainz' },
+        false,
+        'external'
+      )),
+      ...releaseGroups.map(rg => albumToResult(
+        {
+          id: rg.id,
+          title: rg.title,
+          subtext: rg['first-release-date']?.slice(0, 4) ?? '',
+          cover: { kind: 'coverartarchive', mbid: rg.id, mbidType: 'release-group' },
+          externalSource: 'musicbrainz',
+          externalIds: { mbid: rg.id },
+        },
+        'external',
+        false
+      )),
+    ];
+  }
+
+  return [];
+}
+
 // ---
 
 const SearchContext = createContext<SearchContextType | undefined>(
@@ -180,8 +254,8 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
   const isOffline = useIsOffline();
   const serverUnreachable = useServerUnreachable();
   const canReachServer = !isOffline && !serverUnreachable;
-  // Deezer is a public API, so it only needs the device to be online — an
-  // unreachable *music server* says nothing about whether Deezer is up.
+  // External sources are public APIs, so they only need the device to be
+  // online — an unreachable *music server* says nothing about whether they're up.
   const canReachExternal = !isOffline;
 
   const {
@@ -291,20 +365,32 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     ];
   }, [api, downloadedAlbumIds, downloadedTrackIds]);
 
+  /**
+   * Fans a query out to every requested external source in parallel and
+   * concatenates the results with each source's own `externalSource` tag
+   * intact — this is the "Other sources" leg, never mixed with the library
+   * legs above (see `planSearchLegs`).
+   *
+   * Deliberately does not merge across sources: a MusicBrainz release group
+   * and a Deezer album for the same record are two different editions/ids
+   * with no shared key to merge on here (no ISRC/UPC cross-match is computed
+   * at query time), so collapsing them would either drop a real edition or
+   * guess at a match with no confidence signal. Keeping them as separate,
+   * source-labelled rows is the conservative choice the locked design calls
+   * for ("keep editions/recordings and ambiguous matches separate").
+   * `dedupeAndSort`'s existing key (`source:type:id`) still collapses true
+   * duplicates — the same source returning the same id twice.
+   */
   const searchExternal = useCallback(async (
-    query: string
+    query: string,
+    sourceIds: string[],
+    entityTypes: SearchEntityType[]
   ): Promise<SearchResult[]> => {
-    if (!query.trim()) return [];
-
-    const [deezerArtists, deezerAlbums] = await Promise.all([
-      deezer.searchDeezerArtists(query, 4),
-      deezer.searchDeezerAlbums(query, 6),
-    ]);
-
-    return [
-      ...deezerArtists.map(artist => artistToResult(artist, false, 'external')),
-      ...deezerAlbums.map(album => albumToResult(album, 'external', false)),
-    ];
+    if (!query.trim() || sourceIds.length === 0) return [];
+    const perSource = await Promise.all(
+      sourceIds.map(sourceId => searchExternalSource(sourceId, query, entityTypes))
+    );
+    return perSource.flat();
   }, []);
 
   const clearSearch = useCallback(() => {
@@ -329,14 +415,17 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
     try {
       const lowerQuery = query.toLowerCase();
       const results: SearchResult[] = [];
+      const entityTypes = filters.entityTypes ?? ['album', 'artist'];
 
       // Decide the legs up front rather than at each call site. A leg that
       // cannot land is not attempted at all: each one would otherwise hang to
       // its own timeout on every keystroke and then land in the same `catch`
       // as a real failure, so local results that succeeded were shown
-      // underneath an error banner.
+      // underneath an error banner. Library and external legs are mutually
+      // exclusive here — `resultScope` picks one family, never both.
       const legs = planSearchLegs({
-        filters,
+        resultScope: filters.resultScope,
+        enabledExternalSourceIds: filters.sourceIds,
         searchScope,
         serverReachable: canReachServer,
         deviceOnline: canReachExternal,
@@ -352,8 +441,8 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({
       }
       if (requestId !== searchRequestIdRef.current) return;
 
-      if (legs.external) {
-        try { results.push(...await searchExternal(query)); } catch { errored = true; }
+      if (legs.externalSources.length > 0) {
+        try { results.push(...await searchExternal(query, legs.externalSources, entityTypes)); } catch { errored = true; }
       }
       if (requestId !== searchRequestIdRef.current) return;
 

--- a/src/contexts/searchLegs.test.ts
+++ b/src/contexts/searchLegs.test.ts
@@ -1,25 +1,25 @@
 import { planSearchLegs } from './searchLegs';
 
-const BOTH_FILTERS = { local: true, deezer: true };
-
 describe('planSearchLegs', () => {
-  it('attempts every leg the scope asks for when everything is reachable', () => {
+  it('attempts the server leg for the library scope when everything is reachable', () => {
     expect(planSearchLegs({
-      filters: BOTH_FILTERS,
+      resultScope: 'library',
+      enabledExternalSourceIds: [],
       searchScope: 'server',
       serverReachable: true,
       deviceOnline: true,
-    })).toEqual({ client: false, server: true, external: true, degraded: false });
+    })).toEqual({ client: false, server: true, externalSources: [], degraded: false });
   });
 
   it('searches the local index when that is the chosen scope', () => {
     const plan = planSearchLegs({
-      filters: { local: true, deezer: false },
+      resultScope: 'library',
+      enabledExternalSourceIds: [],
       searchScope: 'client',
       serverReachable: true,
       deviceOnline: true,
     });
-    expect(plan).toEqual({ client: true, server: false, external: false, degraded: false });
+    expect(plan).toEqual({ client: true, server: false, externalSources: [], degraded: false });
   });
 
   // The regression this file exists for: offline, the server leg was still
@@ -28,7 +28,8 @@ describe('planSearchLegs', () => {
   // shown under an error banner.
   it('reports a skipped leg as degraded rather than failed', () => {
     expect(planSearchLegs({
-      filters: BOTH_FILTERS,
+      resultScope: 'library',
+      enabledExternalSourceIds: [],
       searchScope: 'server',
       serverReachable: false,
       deviceOnline: true,
@@ -39,7 +40,8 @@ describe('planSearchLegs', () => {
   // over a fully synced library returns nothing at all, which is what it did.
   it('falls back to the local index when the server scope cannot be reached', () => {
     const plan = planSearchLegs({
-      filters: { local: true, deezer: false },
+      resultScope: 'library',
+      enabledExternalSourceIds: [],
       searchScope: 'server',
       serverReachable: false,
       deviceOnline: false,
@@ -49,38 +51,76 @@ describe('planSearchLegs', () => {
     expect(plan.degraded).toBe(true);
   });
 
-  it('still asks Deezer when only the music server is unreachable', () => {
-    // A downed VPN takes the server away while the internet is fine. Folding
-    // both into one flag would drop external results in that exact case.
-    const plan = planSearchLegs({
-      filters: BOTH_FILTERS,
-      searchScope: 'server',
-      serverReachable: false,
-      deviceOnline: true,
-    });
-    expect(plan.server).toBe(false);
-    expect(plan.external).toBe(true);
-  });
-
-  it('is not degraded when the only unreachable leg was never asked for', () => {
+  it('is not degraded when nothing was asked for beyond the local index', () => {
     expect(planSearchLegs({
-      filters: { local: true, deezer: false },
+      resultScope: 'library',
+      enabledExternalSourceIds: [],
       searchScope: 'client',
       serverReachable: false,
       deviceOnline: false,
-    })).toEqual({ client: true, server: false, external: false, degraded: false });
+    })).toEqual({ client: true, server: false, externalSources: [], degraded: false });
   });
 
-  it('drops the local legs entirely when the local filter is off', () => {
-    const plan = planSearchLegs({
-      filters: { local: false, deezer: true },
-      searchScope: 'server',
-      serverReachable: false,
-      deviceOnline: true,
+  describe('resultScope: other (the external-search action)', () => {
+    it('never plans a library leg alongside external ones — the two are not mixed by default', () => {
+      const plan = planSearchLegs({
+        resultScope: 'other',
+        enabledExternalSourceIds: ['deezer', 'musicbrainz'],
+        searchScope: 'server',
+        serverReachable: true,
+        deviceOnline: true,
+      });
+      expect(plan.client).toBe(false);
+      expect(plan.server).toBe(false);
+      expect(plan.externalSources.sort()).toEqual(['deezer', 'musicbrainz']);
     });
-    expect(plan.client).toBe(false);
-    expect(plan.server).toBe(false);
-    expect(plan.external).toBe(true);
-    expect(plan.degraded).toBe(false);
+
+    it('queries only the sources the Filters sheet enabled', () => {
+      const plan = planSearchLegs({
+        resultScope: 'other',
+        enabledExternalSourceIds: ['musicbrainz'],
+        searchScope: 'server',
+        serverReachable: true,
+        deviceOnline: true,
+      });
+      expect(plan.externalSources).toEqual(['musicbrainz']);
+    });
+
+    it('drops every external source when the device is offline', () => {
+      const plan = planSearchLegs({
+        resultScope: 'other',
+        enabledExternalSourceIds: ['deezer'],
+        searchScope: 'server',
+        serverReachable: true,
+        deviceOnline: false,
+      });
+      expect(plan.externalSources).toEqual([]);
+      expect(plan.degraded).toBe(true);
+    });
+
+    it('is not degraded when the scope was asked for with no sources enabled at all', () => {
+      // Nothing to attempt is not the same as something failing to reach.
+      const plan = planSearchLegs({
+        resultScope: 'other',
+        enabledExternalSourceIds: [],
+        searchScope: 'server',
+        serverReachable: true,
+        deviceOnline: true,
+      });
+      expect(plan.externalSources).toEqual([]);
+      expect(plan.degraded).toBe(false);
+    });
+
+    it('never attempts the library legs even when the search scope is client', () => {
+      const plan = planSearchLegs({
+        resultScope: 'other',
+        enabledExternalSourceIds: ['deezer'],
+        searchScope: 'client',
+        serverReachable: true,
+        deviceOnline: true,
+      });
+      expect(plan.client).toBe(false);
+      expect(plan.server).toBe(false);
+    });
   });
 });

--- a/src/contexts/searchLegs.ts
+++ b/src/contexts/searchLegs.ts
@@ -1,5 +1,11 @@
 export type SearchScope = 'client' | 'server';
 
+/** The scope of a search: the user's own library, or intentionally reaching
+ *  out to other sources. Distinct from `SearchScope` above, which is about
+ *  *how* the library leg is fetched (locally-indexed vs. the music server),
+ *  not about whether external sources are in play at all. */
+export type SearchResultScope = 'library' | 'other';
+
 /**
  * Which legs of a search are worth attempting.
  *
@@ -12,10 +18,10 @@ export type SearchScope = 'client' | 'server';
  *
  * The two reachability inputs are deliberately separate. `serverReachable` is
  * about the user's own music server (which a downed VPN takes away while the
- * device stays online); `deviceOnline` is about the internet at large. Deezer
- * needs only the second — an unreachable Navidrome says nothing about whether
- * Deezer is up — so folding them into one flag would silently drop external
- * results in the most common failure case.
+ * device stays online); `deviceOnline` is about the internet at large. External
+ * sources need only the second — an unreachable Navidrome says nothing about
+ * whether Deezer or MusicBrainz are up — so folding them into one flag would
+ * silently drop external results in the most common failure case.
  *
  * **Scope is one or the other, not a set.** `searchScope` is a single value and
  * the old code tested it with `String.prototype.includes`, which reads like an
@@ -25,15 +31,20 @@ export type SearchScope = 'client' | 'server';
  * at all. Hence `client` below is *not* simply `scope === 'client'` — a server
  * scope degrades to the local index rather than to an empty screen, which is
  * the whole point of having a synced library.
+ *
+ * **Library and external are never both attempted.** `resultScope` decides
+ * which family runs at all: `'library'` only ever plans the client/server
+ * legs, `'other'` only ever plans external ones — the segmented Search UI's
+ * "Your Library" / "Other sources" choice, not an additional filter on top of
+ * it. Mixing the two by default was explicitly ruled out.
  */
-
 export type SearchLegPlan = {
   /** Search the locally synced library index. */
   client: boolean;
   /** Ask the music server. */
   server: boolean;
-  /** Ask Deezer. */
-  external: boolean;
+  /** Which external sources to query — empty unless `resultScope` is `'other'`. */
+  externalSources: string[];
   /**
    * A leg the filters asked for was skipped because it couldn't be reached, so
    * the results are narrower than requested through no fault of the query.
@@ -42,31 +53,38 @@ export type SearchLegPlan = {
 };
 
 export function planSearchLegs({
-  filters,
+  resultScope,
+  enabledExternalSourceIds,
   searchScope,
   serverReachable,
   deviceOnline,
 }: {
-  filters: { local: boolean; deezer: boolean };
+  /** 'library' (default) or 'other' — the segmented scope control's value. */
+  resultScope: SearchResultScope;
+  /** Source ids enabled for search AND selected in the Filters sheet. */
+  enabledExternalSourceIds: string[];
   searchScope: SearchScope;
   serverReachable: boolean;
   deviceOnline: boolean;
 }): SearchLegPlan {
-  const wantsServer = filters.local && searchScope === 'server';
-  const wantsExternal = filters.deezer;
+  const isLibraryScope = resultScope === 'library';
+  const isOtherScope = resultScope === 'other';
+
+  const wantsServer = isLibraryScope && searchScope === 'server';
+  const wantsExternal = isOtherScope && enabledExternalSourceIds.length > 0;
 
   const server = wantsServer && serverReachable;
-  const external = wantsExternal && deviceOnline;
+  const externalSources = wantsExternal && deviceOnline ? enabledExternalSourceIds : [];
 
-  // The local index when it was asked for, and also whenever the server leg
-  // was wanted but can't run — otherwise the default scope means an offline
-  // search over a fully synced library shows nothing.
-  const client = filters.local && (searchScope === 'client' || (wantsServer && !server));
+  // The local index when the library scope was asked for, and also whenever
+  // the server leg was wanted but can't run — otherwise the default scope
+  // means an offline search over a fully synced library shows nothing.
+  const client = isLibraryScope && (searchScope === 'client' || (wantsServer && !server));
 
   return {
     client,
     server,
-    external,
-    degraded: (wantsServer && !server) || (wantsExternal && !external),
+    externalSources,
+    degraded: (wantsServer && !server) || (wantsExternal && externalSources.length === 0),
   };
 }

--- a/src/enums/queryKeys.ts
+++ b/src/enums/queryKeys.ts
@@ -45,4 +45,5 @@ export enum QueryKeys {
 	ServerSimilarAlbums = 'server-similar-albums',
 	LocalArtistTopTracks = 'local-artist-top-tracks',
 	LocalArtistExternalDiscography = 'local-artist-external-discography',
+	MetadataArtistInfo = 'metadata-artist-info',
 }

--- a/src/features/lyrics/externalLyricsFetchers.ts
+++ b/src/features/lyrics/externalLyricsFetchers.ts
@@ -1,0 +1,15 @@
+import { getLyrics as getLrclibLyrics } from "@/api/lrclib";
+import type { ExternalLyricsFetchers } from "./resolveLyrics";
+
+/** The real (network-backed) fetcher for every external lyrics source the
+ *  app knows about. Kept separate from `resolveLyrics` so tests can inject
+ *  fakes instead of this module. */
+export const externalLyricsFetchers: ExternalLyricsFetchers = {
+  lrclib: song =>
+    getLrclibLyrics({
+      artist: song.artist,
+      title: song.title,
+      album: song.album,
+      durationSec: song.durationSec,
+    }),
+};

--- a/src/features/lyrics/resolveLyrics.test.ts
+++ b/src/features/lyrics/resolveLyrics.test.ts
@@ -1,0 +1,103 @@
+import { resolveLyrics } from "./resolveLyrics";
+import type { LyricsResult } from "@/api/types";
+import type { LyricsSongInfo } from "./resolveLyrics";
+
+const song: LyricsSongInfo = { songId: "s1", title: "T", artist: "A" };
+
+const serverResult: LyricsResult = { provider: "navidrome", synced: true, lines: [{ startMs: 0, text: "server" }] };
+const lrclibResult: LyricsResult = { provider: "lrclib", synced: true, lines: [{ startMs: 0, text: "lrclib" }] };
+
+describe("resolveLyrics", () => {
+  it("returns the server result without calling any external source", async () => {
+    const getServerLyrics = jest.fn().mockResolvedValue(serverResult);
+    const lrclibFetcher = jest.fn();
+
+    const result = await resolveLyrics({
+      song,
+      getServerLyrics,
+      enabledExternalSourcesInOrder: ["lrclib"],
+      fetchers: { lrclib: lrclibFetcher },
+    });
+
+    expect(result).toEqual(serverResult);
+    expect(lrclibFetcher).not.toHaveBeenCalled();
+  });
+
+  it("is server-only when nothing external is enabled (today's behavior)", async () => {
+    const getServerLyrics = jest.fn().mockResolvedValue(null);
+    const lrclibFetcher = jest.fn().mockResolvedValue(lrclibResult);
+
+    const result = await resolveLyrics({
+      song,
+      getServerLyrics,
+      enabledExternalSourcesInOrder: [],
+      fetchers: { lrclib: lrclibFetcher },
+    });
+
+    expect(result).toBeNull();
+    expect(lrclibFetcher).not.toHaveBeenCalled();
+  });
+
+  it("falls through to an enabled external source when the server has nothing", async () => {
+    const getServerLyrics = jest.fn().mockResolvedValue(null);
+    const lrclibFetcher = jest.fn().mockResolvedValue(lrclibResult);
+
+    const result = await resolveLyrics({
+      song,
+      getServerLyrics,
+      enabledExternalSourcesInOrder: ["lrclib"],
+      fetchers: { lrclib: lrclibFetcher },
+    });
+
+    expect(result).toEqual(lrclibResult);
+    expect(lrclibFetcher).toHaveBeenCalledWith(song);
+  });
+
+  it("treats an empty-lines server result the same as no result", async () => {
+    const getServerLyrics = jest.fn().mockResolvedValue({ provider: "navidrome", synced: true, lines: [] });
+    const lrclibFetcher = jest.fn().mockResolvedValue(lrclibResult);
+
+    const result = await resolveLyrics({
+      song,
+      getServerLyrics,
+      enabledExternalSourcesInOrder: ["lrclib"],
+      fetchers: { lrclib: lrclibFetcher },
+    });
+
+    expect(result).toEqual(lrclibResult);
+  });
+
+  it("tries sources in the user's order and stops at the first hit, skipping later ones", async () => {
+    // Only "lrclib" ships today, but the resolver is generic over the id
+    // type — this proves order/short-circuit behavior ahead of a second
+    // real source existing, using a second fake id cast for the test.
+    const getServerLyrics = jest.fn().mockResolvedValue(null);
+    const first = jest.fn().mockResolvedValue(lrclibResult);
+    const second = jest.fn().mockResolvedValue(lrclibResult);
+
+    const result = await resolveLyrics({
+      song,
+      getServerLyrics,
+      enabledExternalSourcesInOrder: ["second", "lrclib"] as unknown as ["lrclib"],
+      fetchers: { lrclib: first, second } as unknown as { lrclib: typeof first },
+    });
+
+    expect(second).toHaveBeenCalled();
+    expect(first).not.toHaveBeenCalled();
+    expect(result).toEqual(lrclibResult);
+  });
+
+  it("returns null when server and every external source miss", async () => {
+    const getServerLyrics = jest.fn().mockResolvedValue(null);
+    const lrclibFetcher = jest.fn().mockResolvedValue(null);
+
+    const result = await resolveLyrics({
+      song,
+      getServerLyrics,
+      enabledExternalSourcesInOrder: ["lrclib"],
+      fetchers: { lrclib: lrclibFetcher },
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/features/lyrics/resolveLyrics.ts
+++ b/src/features/lyrics/resolveLyrics.ts
@@ -1,0 +1,67 @@
+import type { LyricsResult } from "@/api/types";
+
+/**
+ * The one external source available today. A plain string union (rather than
+ * an enum) keeps the redux slice's persisted value a plain JSON string.
+ */
+export type ExternalLyricsSourceId = "lrclib";
+
+export const ALL_EXTERNAL_LYRICS_SOURCES: readonly ExternalLyricsSourceId[] = ["lrclib"];
+
+/** Enough about the current song for an external source to look itself up. */
+export type LyricsSongInfo = {
+  songId: string;
+  title: string;
+  artist: string;
+  album?: string;
+  /** Seconds. LRCLIB uses this to disambiguate same-named tracks. */
+  durationSec?: number;
+};
+
+export type ExternalLyricsFetcher = (song: LyricsSongInfo) => Promise<LyricsResult | null>;
+
+/** One fetcher per source id. Extending the fallback chain with a second
+ *  external source only means adding an entry here and to
+ *  `ALL_EXTERNAL_LYRICS_SOURCES` — nothing else in this file changes. */
+export type ExternalLyricsFetchers = Partial<Record<ExternalLyricsSourceId, ExternalLyricsFetcher>>;
+
+export type ResolveLyricsInput = {
+  song: LyricsSongInfo;
+  /** The server-embedded lookup — always tried first, unconditionally. */
+  getServerLyrics: (songId: string) => Promise<LyricsResult | null>;
+  /** The user's fallback order, enabled sources only, most-preferred first.
+   *  Disabled sources are simply absent from this list — there is no
+   *  separate enabled/disabled bit to reconcile against the order here. */
+  enabledExternalSourcesInOrder: ExternalLyricsSourceId[];
+  fetchers: ExternalLyricsFetchers;
+};
+
+/**
+ * Server-embedded lyrics first, then each enabled external source in the
+ * user's chosen order, stopping at the first non-empty result.
+ *
+ * When `enabledExternalSourcesInOrder` is empty — the default, since every
+ * external source ships off — this behaves exactly like the bare
+ * `api.lyrics.getBySongId()` call it replaces: server-only, no external
+ * network calls at all.
+ */
+export async function resolveLyrics(input: ResolveLyricsInput): Promise<LyricsResult | null> {
+  const { song, getServerLyrics, enabledExternalSourcesInOrder, fetchers } = input;
+
+  const serverResult = await getServerLyrics(song.songId);
+  if (serverResult && serverResult.lines.length > 0) {
+    return serverResult;
+  }
+
+  for (const sourceId of enabledExternalSourcesInOrder) {
+    const fetcher = fetchers[sourceId];
+    if (!fetcher) continue;
+
+    const result = await fetcher(song);
+    if (result && result.lines.length > 0) {
+      return result;
+    }
+  }
+
+  return null;
+}

--- a/src/features/metadata/enrichmentFetchers.ts
+++ b/src/features/metadata/enrichmentFetchers.ts
@@ -1,0 +1,113 @@
+/**
+ * Real (network-backed) fetchers for every metadata.enrich source. Kept
+ * separate from `resolveArtistInfo`/`resolveArtwork` so tests inject fakes
+ * instead of this module — same split as `features/lyrics`.
+ *
+ * Each fetcher is wrapped in a small bounded in-memory cache: enrichment
+ * lookups are keyed by artist name (lowercased) and never expire mid-session,
+ * capped at a low entry count evicted oldest-first, mirroring the shape of
+ * `api/deezer`'s own request cache without pulling in that module's TTL
+ * machinery (these results are much more stable than chart/album data).
+ */
+import { getLastFmArtistInfo } from '@/api/lastfm';
+import { getDeezerArtist } from '@/api/deezer';
+import { coverArtArchiveUrl } from '@/api/musicbrainz';
+import { LASTFM_API_KEY } from '@/constants/keys';
+import type { ArtistInfoFetchers, ArtistInfoResult } from './resolveArtistInfo';
+import type { ArtworkFetchers, ArtworkResult } from './resolveArtwork';
+
+const MAX_CACHE_ENTRIES = 200;
+
+function boundedCache<T>() {
+  const map = new Map<string, T>();
+  return {
+    get(key: string): T | undefined {
+      return map.get(key);
+    },
+    set(key: string, value: T): void {
+      if (map.size >= MAX_CACHE_ENTRIES && !map.has(key)) {
+        const oldestKey = map.keys().next().value;
+        if (oldestKey !== undefined) map.delete(oldestKey);
+      }
+      map.set(key, value);
+    },
+  };
+}
+
+const artistInfoCache = boundedCache<ArtistInfoResult | null>();
+const artworkCache = boundedCache<ArtworkResult | null>();
+
+export const metadataArtistInfoFetchers: ArtistInfoFetchers = {
+  lastfm: async artist => {
+    const key = `lastfm:${artist.name.trim().toLowerCase()}`;
+    const cached = artistInfoCache.get(key);
+    if (cached !== undefined) return cached;
+
+    if (!LASTFM_API_KEY || !artist.name.trim()) {
+      artistInfoCache.set(key, null);
+      return null;
+    }
+
+    const info = await getLastFmArtistInfo(LASTFM_API_KEY, artist.name);
+    const result: ArtistInfoResult | null = info
+      ? { bio: info.bio, tags: info.tags, source: 'lastfm' }
+      : null;
+    artistInfoCache.set(key, result);
+    return result;
+  },
+};
+
+export const metadataArtworkFetchers: ArtworkFetchers = {
+  deezer: async entity => {
+    const key = `deezer:${entity.name.trim().toLowerCase()}`;
+    const cached = artworkCache.get(key);
+    if (cached !== undefined) return cached;
+
+    if (!entity.name.trim()) {
+      artworkCache.set(key, null);
+      return null;
+    }
+
+    // Deezer artist images are looked up by id, not name — resolve via the
+    // existing name search before fetching the artist record.
+    const { resolveDeezerArtistByName } = await import('@/api/deezer/catalog');
+    const resolved = await resolveDeezerArtistByName(entity.name);
+    if (!resolved) {
+      artworkCache.set(key, null);
+      return null;
+    }
+    const full = await getDeezerArtist(resolved.id);
+    const result: ArtworkResult | null =
+      full && full.cover.kind !== 'none' ? { cover: full.cover, source: 'deezer' } : null;
+    artworkCache.set(key, result);
+    return result;
+  },
+
+  coverartarchive: async entity => {
+    if (!entity.mbid) return null;
+    const key = `coverartarchive:${entity.mbid}`;
+    const cached = artworkCache.get(key);
+    if (cached !== undefined) return cached;
+
+    // Cover Art Archive has no "does this exist" endpoint cheaper than a
+    // HEAD request against the front image; a cache hit here means we don't
+    // repeat that request for the same release/release-group.
+    const url = coverArtArchiveUrl(entity.mbid);
+    let exists = false;
+    try {
+      const res = await fetch(url, { method: 'HEAD' });
+      exists = res.ok;
+    } catch {
+      exists = false;
+    }
+
+    const result: ArtworkResult | null = exists
+      ? {
+          cover: { kind: 'coverartarchive', mbid: entity.mbid, mbidType: entity.mbidType ?? 'release-group' },
+          source: 'coverartarchive',
+        }
+      : null;
+    artworkCache.set(key, result);
+    return result;
+  },
+};

--- a/src/features/metadata/resolveArtistInfo.test.ts
+++ b/src/features/metadata/resolveArtistInfo.test.ts
@@ -1,0 +1,77 @@
+import { resolveArtistInfo } from './resolveArtistInfo';
+import type { ArtistInfoInput, ArtistInfoResult } from './resolveArtistInfo';
+
+const artist: ArtistInfoInput = { name: 'Radiohead', mbid: 'abc-123' };
+
+const lastfmResult: ArtistInfoResult = {
+  bio: 'An English rock band.',
+  tags: ['alternative', 'rock'],
+  source: 'lastfm',
+};
+
+describe('resolveArtistInfo', () => {
+  it('is a no-op when nothing is enabled (server view preserved)', async () => {
+    const lastfmFetcher = jest.fn().mockResolvedValue(lastfmResult);
+
+    const result = await resolveArtistInfo({
+      artist,
+      enabledSourcesInOrder: [],
+      fetchers: { lastfm: lastfmFetcher },
+    });
+
+    expect(result).toBeNull();
+    expect(lastfmFetcher).not.toHaveBeenCalled();
+  });
+
+  it('returns the first enabled source that has data', async () => {
+    const lastfmFetcher = jest.fn().mockResolvedValue(lastfmResult);
+
+    const result = await resolveArtistInfo({
+      artist,
+      enabledSourcesInOrder: ['lastfm'],
+      fetchers: { lastfm: lastfmFetcher },
+    });
+
+    expect(result).toEqual(lastfmResult);
+    expect(lastfmFetcher).toHaveBeenCalledWith(artist);
+  });
+
+  it('tries sources in the user order and stops at the first hit', async () => {
+    const first = jest.fn().mockResolvedValue(lastfmResult);
+    const second = jest.fn().mockResolvedValue(lastfmResult);
+
+    const result = await resolveArtistInfo({
+      artist,
+      enabledSourcesInOrder: ['second', 'lastfm'] as unknown as ['lastfm'],
+      fetchers: { lastfm: first, second } as unknown as { lastfm: typeof first },
+    });
+
+    expect(second).toHaveBeenCalled();
+    expect(first).not.toHaveBeenCalled();
+    expect(result).toEqual(lastfmResult);
+  });
+
+  it('treats an empty bio and empty tags result as a miss', async () => {
+    const lastfmFetcher = jest.fn().mockResolvedValue({ bio: null, tags: [], source: 'lastfm' });
+
+    const result = await resolveArtistInfo({
+      artist,
+      enabledSourcesInOrder: ['lastfm'],
+      fetchers: { lastfm: lastfmFetcher },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when every enabled source misses', async () => {
+    const lastfmFetcher = jest.fn().mockResolvedValue(null);
+
+    const result = await resolveArtistInfo({
+      artist,
+      enabledSourcesInOrder: ['lastfm'],
+      fetchers: { lastfm: lastfmFetcher },
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/features/metadata/resolveArtistInfo.ts
+++ b/src/features/metadata/resolveArtistInfo.ts
@@ -1,0 +1,71 @@
+/**
+ * `metadata.enrich`: display-only artist-info gap-filling, never written back
+ * to any server. See `docs/design-library-intent.md` §9 for the design and
+ * `resolveArtwork.ts` for the artwork half of the pair — the two chains are
+ * deliberately independent (a user can enable one without the other).
+ *
+ * GAPS ONLY: this resolver is only ever consulted when the caller already
+ * knows the server/local entity has no bio — it does not itself decide that,
+ * so it never overrides server data.
+ *
+ * DISPLAY ONLY: nothing here writes to a server, a file, or a tag. It only
+ * returns data for the UI to render, alongside which source it came from so
+ * the UI can draw the small "via …" source line.
+ */
+
+/** Every artist-info source the app knows how to fill this slot with. */
+export type ArtistInfoSourceId = 'lastfm';
+
+export const ALL_ARTIST_INFO_SOURCES: readonly ArtistInfoSourceId[] = ['lastfm'];
+
+export type ArtistInfoResult = {
+  bio: string | null;
+  tags: string[];
+  /** Which source produced this — drives the "via Last.fm" source line. */
+  source: ArtistInfoSourceId;
+};
+
+/** Enough about the artist for a source to look itself up. */
+export type ArtistInfoInput = {
+  name: string;
+  mbid?: string | null;
+};
+
+export type ArtistInfoFetcher = (artist: ArtistInfoInput) => Promise<ArtistInfoResult | null>;
+
+/** One fetcher per source id. Adding a second launch source only means an
+ *  entry here and in `ALL_ARTIST_INFO_SOURCES`. */
+export type ArtistInfoFetchers = Partial<Record<ArtistInfoSourceId, ArtistInfoFetcher>>;
+
+export type ResolveArtistInfoInput = {
+  artist: ArtistInfoInput;
+  /** The user's fallback order, enabled sources only, most-preferred first.
+   *  Disabled sources are simply absent — there is no separate bit to
+   *  reconcile against the order here. An empty list (the default, since
+   *  metadata enrichment ships off) makes this resolver a no-op, which is
+   *  exactly what "disabling restores the server view" requires. */
+  enabledSourcesInOrder: ArtistInfoSourceId[];
+  fetchers: ArtistInfoFetchers;
+};
+
+/**
+ * Tries each enabled source in the user's order, stopping at the first one
+ * that returns a non-empty bio or tag list. Returns `null` when every source
+ * misses or none are enabled — the caller falls back to showing nothing,
+ * which is what the server-only view already does today.
+ */
+export async function resolveArtistInfo(input: ResolveArtistInfoInput): Promise<ArtistInfoResult | null> {
+  const { artist, enabledSourcesInOrder, fetchers } = input;
+
+  for (const sourceId of enabledSourcesInOrder) {
+    const fetcher = fetchers[sourceId];
+    if (!fetcher) continue;
+
+    const result = await fetcher(artist);
+    if (result && (result.bio || result.tags.length > 0)) {
+      return result;
+    }
+  }
+
+  return null;
+}

--- a/src/features/metadata/resolveArtwork.test.ts
+++ b/src/features/metadata/resolveArtwork.test.ts
@@ -1,0 +1,97 @@
+import { resolveArtwork } from './resolveArtwork';
+import type { ArtworkLookupInput, ArtworkResult } from './resolveArtwork';
+
+const entity: ArtworkLookupInput = { name: 'Radiohead', mbid: 'abc-123', mbidType: 'release-group' };
+
+const deezerResult: ArtworkResult = {
+  cover: { kind: 'url', url: 'https://example.com/artist.jpg' },
+  source: 'deezer',
+};
+
+const cazResult: ArtworkResult = {
+  cover: { kind: 'coverartarchive', mbid: 'abc-123', mbidType: 'release-group' },
+  source: 'coverartarchive',
+};
+
+describe('resolveArtwork', () => {
+  it('is a no-op when nothing is enabled (server view preserved)', async () => {
+    const deezerFetcher = jest.fn().mockResolvedValue(deezerResult);
+
+    const result = await resolveArtwork({
+      entity,
+      enabledSourcesInOrder: [],
+      fetchers: { deezer: deezerFetcher },
+    });
+
+    expect(result).toBeNull();
+    expect(deezerFetcher).not.toHaveBeenCalled();
+  });
+
+  it('returns the first enabled source that has artwork', async () => {
+    const deezerFetcher = jest.fn().mockResolvedValue(deezerResult);
+
+    const result = await resolveArtwork({
+      entity,
+      enabledSourcesInOrder: ['deezer'],
+      fetchers: { deezer: deezerFetcher },
+    });
+
+    expect(result).toEqual(deezerResult);
+    expect(deezerFetcher).toHaveBeenCalledWith(entity);
+  });
+
+  it('falls through to the next enabled source when the first misses', async () => {
+    const deezerFetcher = jest.fn().mockResolvedValue(null);
+    const cazFetcher = jest.fn().mockResolvedValue(cazResult);
+
+    const result = await resolveArtwork({
+      entity,
+      enabledSourcesInOrder: ['deezer', 'coverartarchive'],
+      fetchers: { deezer: deezerFetcher, coverartarchive: cazFetcher },
+    });
+
+    expect(result).toEqual(cazResult);
+    expect(deezerFetcher).toHaveBeenCalled();
+    expect(cazFetcher).toHaveBeenCalled();
+  });
+
+  it('honors the user order — coverartarchive first skips deezer entirely', async () => {
+    const deezerFetcher = jest.fn().mockResolvedValue(deezerResult);
+    const cazFetcher = jest.fn().mockResolvedValue(cazResult);
+
+    const result = await resolveArtwork({
+      entity,
+      enabledSourcesInOrder: ['coverartarchive', 'deezer'],
+      fetchers: { deezer: deezerFetcher, coverartarchive: cazFetcher },
+    });
+
+    expect(result).toEqual(cazResult);
+    expect(cazFetcher).toHaveBeenCalled();
+    expect(deezerFetcher).not.toHaveBeenCalled();
+  });
+
+  it('treats a "none" cover as a miss', async () => {
+    const deezerFetcher = jest.fn().mockResolvedValue({ cover: { kind: 'none' }, source: 'deezer' });
+
+    const result = await resolveArtwork({
+      entity,
+      enabledSourcesInOrder: ['deezer'],
+      fetchers: { deezer: deezerFetcher },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when every enabled source misses', async () => {
+    const deezerFetcher = jest.fn().mockResolvedValue(null);
+    const cazFetcher = jest.fn().mockResolvedValue(null);
+
+    const result = await resolveArtwork({
+      entity,
+      enabledSourcesInOrder: ['deezer', 'coverartarchive'],
+      fetchers: { deezer: deezerFetcher, coverartarchive: cazFetcher },
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/features/metadata/resolveArtwork.ts
+++ b/src/features/metadata/resolveArtwork.ts
@@ -1,0 +1,64 @@
+/**
+ * `metadata.enrich`: display-only artwork gap-filling. Mirrors
+ * `resolveArtistInfo.ts`'s shape but is an intentionally independent chain —
+ * a user can enable artist-info without artwork, or vice versa (LOCKED
+ * DESIGN, see the D3 task). Never writes to a server; only ever consulted
+ * when the caller already knows the entity has no artwork of its own.
+ */
+
+import type { CoverSource } from '@/types/Cover';
+
+/** Every artwork source the app knows how to fill this slot with. */
+export type ArtworkSourceId = 'deezer' | 'coverartarchive';
+
+export const ALL_ARTWORK_SOURCES: readonly ArtworkSourceId[] = ['deezer', 'coverartarchive'];
+
+export type ArtworkResult = {
+  cover: CoverSource;
+  /** Which source produced this — drives the "via Deezer" / "via Cover Art
+   *  Archive" source line. */
+  source: ArtworkSourceId;
+};
+
+/** Enough about the entity for a source to look itself up. `mbid` is what
+ *  Cover Art Archive needs (a release or release-group MBID); `name` is
+ *  what Deezer's artist-image lookup needs. Either may be absent. */
+export type ArtworkLookupInput = {
+  name: string;
+  mbid?: string | null;
+  mbidType?: 'release' | 'release-group' | 'unknown';
+};
+
+export type ArtworkFetcher = (entity: ArtworkLookupInput) => Promise<ArtworkResult | null>;
+
+/** One fetcher per source id. */
+export type ArtworkFetchers = Partial<Record<ArtworkSourceId, ArtworkFetcher>>;
+
+export type ResolveArtworkInput = {
+  entity: ArtworkLookupInput;
+  /** The user's fallback order, enabled sources only, most-preferred first.
+   *  Empty (the default) makes this resolver a no-op. */
+  enabledSourcesInOrder: ArtworkSourceId[];
+  fetchers: ArtworkFetchers;
+};
+
+/**
+ * Tries each enabled source in order, stopping at the first hit. Returns
+ * `null` when every source misses or none are enabled, so the caller keeps
+ * showing whatever placeholder/server cover it already had.
+ */
+export async function resolveArtwork(input: ResolveArtworkInput): Promise<ArtworkResult | null> {
+  const { entity, enabledSourcesInOrder, fetchers } = input;
+
+  for (const sourceId of enabledSourcesInOrder) {
+    const fetcher = fetchers[sourceId];
+    if (!fetcher) continue;
+
+    const result = await fetcher(entity);
+    if (result && result.cover.kind !== 'none') {
+      return result;
+    }
+  }
+
+  return null;
+}

--- a/src/features/metadata/useArtistInfoEnrichment.ts
+++ b/src/features/metadata/useArtistInfoEnrichment.ts
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { resolveArtistInfo } from '@/features/metadata/resolveArtistInfo';
+import { metadataArtistInfoFetchers } from '@/features/metadata/enrichmentFetchers';
+import { selectEnabledMetadataArtistInfoSourcesInOrder } from '@/utils/redux/selectors/settingsSelectors';
+import { QueryKeys } from '@/enums/queryKeys';
+
+type Input = {
+  name: string;
+  mbid?: string | null;
+  /** Whether the caller's own (server/Deezer) bio is already present — the
+   *  enrichment lookup is GAPS ONLY, so it stays disabled whenever this is
+   *  true, matching `resolveArtistInfo`'s never-override guarantee at the
+   *  call site as well as inside the resolver. */
+  hasOwnBio: boolean;
+};
+
+export type ArtistInfoEnrichment = {
+  bio: string | null;
+  sourceLabel: string | null;
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  lastfm: 'Last.fm',
+};
+
+/**
+ * `metadata.enrich` (artist-info half) for display in `BioSection`. Returns
+ * `{ bio: null, sourceLabel: null }` whenever enrichment is off, the server
+ * already has a bio, or every enabled source misses — in every one of those
+ * cases the caller's existing (server) bio is what gets shown, which is the
+ * "disabling restores the server view" guarantee.
+ */
+export function useArtistInfoEnrichment({ name, mbid, hasOwnBio }: Input): ArtistInfoEnrichment {
+  const enabledSourcesInOrder = useSelector(selectEnabledMetadataArtistInfoSourcesInOrder);
+  const enabled = !hasOwnBio && !!name && enabledSourcesInOrder.length > 0;
+
+  const query = useQuery({
+    queryKey: [QueryKeys.MetadataArtistInfo, name, enabledSourcesInOrder.join(',')],
+    enabled,
+    staleTime: 1000 * 60 * 60 * 24,
+    networkMode: 'online',
+    queryFn: () =>
+      resolveArtistInfo({
+        artist: { name, mbid },
+        enabledSourcesInOrder: enabledSourcesInOrder as never[],
+        fetchers: metadataArtistInfoFetchers,
+      }),
+  });
+
+  if (!enabled || !query.data) {
+    return { bio: null, sourceLabel: null };
+  }
+
+  return {
+    bio: query.data.bio,
+    sourceLabel: SOURCE_LABELS[query.data.source] ?? query.data.source,
+  };
+}

--- a/src/features/sources/useSearchSourcesEnabled.test.tsx
+++ b/src/features/sources/useSearchSourcesEnabled.test.tsx
@@ -1,0 +1,72 @@
+import React, { type ReactNode } from 'react';
+import { renderHook } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+
+import { useEnabledSearchSourceIds, useSearchSourceEnabled } from './useSearchSourcesEnabled';
+import settingsReducer, {
+  setSearchSourceEnabled,
+  setDeezerDiscoveryEnabled,
+} from '@/utils/redux/slices/settingsSlice';
+
+jest.mock('@/hooks/useIsOffline', () => ({
+  useIsOffline: () => mockIsOffline,
+}));
+
+// eslint-disable-next-line no-var -- hoisted for the jest.mock factory above
+var mockIsOffline = false;
+
+function makeStore() {
+  return configureStore({ reducer: { settings: settingsReducer } });
+}
+
+function wrapper(store: ReturnType<typeof makeStore>) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  Wrapper.displayName = 'TestStoreWrapper';
+  return Wrapper;
+}
+
+describe('useEnabledSearchSourceIds', () => {
+  beforeEach(() => {
+    mockIsOffline = false;
+  });
+
+  it('is empty by default — search enablement is independent of Home', async () => {
+    const store = makeStore();
+    // Turning Home discovery on must not leak into search enablement.
+    store.dispatch(setDeezerDiscoveryEnabled(true));
+    const { result } = await renderHook(() => useEnabledSearchSourceIds(), { wrapper: wrapper(store) });
+    expect(result.current).toEqual([]);
+  });
+
+  it('includes a source once it is explicitly enabled for search', async () => {
+    const store = makeStore();
+    store.dispatch(setSearchSourceEnabled({ sourceId: 'deezer', enabled: true }));
+    const { result } = await renderHook(() => useEnabledSearchSourceIds(), { wrapper: wrapper(store) });
+    expect(result.current).toEqual(['deezer']);
+  });
+
+  it('drops every source while the device is offline', async () => {
+    const store = makeStore();
+    store.dispatch(setSearchSourceEnabled({ sourceId: 'deezer', enabled: true }));
+    store.dispatch(setSearchSourceEnabled({ sourceId: 'musicbrainz', enabled: true }));
+    mockIsOffline = true;
+    const { result } = await renderHook(() => useEnabledSearchSourceIds(), { wrapper: wrapper(store) });
+    expect(result.current).toEqual([]);
+  });
+});
+
+describe('useSearchSourceEnabled', () => {
+  beforeEach(() => {
+    mockIsOffline = false;
+  });
+
+  it('reads one source in isolation', async () => {
+    const store = makeStore();
+    store.dispatch(setSearchSourceEnabled({ sourceId: 'musicbrainz', enabled: true }));
+    const { result } = await renderHook(() => useSearchSourceEnabled('musicbrainz'), { wrapper: wrapper(store) });
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/features/sources/useSearchSourcesEnabled.ts
+++ b/src/features/sources/useSearchSourcesEnabled.ts
@@ -1,0 +1,34 @@
+import { useSelector } from 'react-redux'
+import { useIsOffline } from '@/hooks/useIsOffline'
+import { selectSearchSourceEnabled } from '@/utils/redux/selectors/settingsSelectors'
+import { ALL_SOURCES, type SourceId } from '@/features/sources/registry'
+
+/**
+ * Which sources the user has turned on for Search's "Other sources" scope —
+ * state entirely separate from Home/discovery enablement
+ * (`useDeezerDiscoveryEnabled`, `musicbrainzExternalEnabled`, etc). A source
+ * lighting up a Home shelf says nothing about whether Search may call it;
+ * each surface's enablement is its own on/off switch.
+ *
+ * Mirrors `useDeezerSearchEnabled`'s offline gating: a source enabled in
+ * settings still isn't attempted while the device has no network at all.
+ *
+ * Hooks are called unconditionally, one per known source id — `ALL_SOURCES`
+ * is a fixed module constant, so this is a fixed call count across renders,
+ * not a loop over changing data.
+ */
+export function useEnabledSearchSourceIds(): SourceId[] {
+  const deezerEnabled = useSelector(selectSearchSourceEnabled('deezer'))
+  const musicbrainzEnabled = useSelector(selectSearchSourceEnabled('musicbrainz'))
+  const isOffline = useIsOffline()
+  if (isOffline) return []
+  return ALL_SOURCES
+    .filter(source => (source.id === 'deezer' ? deezerEnabled : musicbrainzEnabled))
+    .map(source => source.id)
+}
+
+export function useSearchSourceEnabled(sourceId: SourceId): boolean {
+  const enabled = useSelector(selectSearchSourceEnabled(sourceId))
+  const isOffline = useIsOffline()
+  return enabled && !isOffline
+}

--- a/src/hooks/scrobbleRouting.test.tsx
+++ b/src/hooks/scrobbleRouting.test.tsx
@@ -4,11 +4,12 @@ import { configureStore, combineReducers } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
 
 import type { Server, Song } from '@/types'
-import settingsReducer from '@/utils/redux/slices/settingsSlice'
+import settingsReducer, { setScrobbleRoute } from '@/utils/redux/slices/settingsSlice'
 import serversReducer, { addServer, setActiveServer } from '@/utils/redux/slices/serversSlice'
-import listenbrainzReducer from '@/utils/redux/slices/listenbrainzSlice'
+import listenbrainzReducer, { setUsername, setToken } from '@/utils/redux/slices/listenbrainzSlice'
 import statsReducer from '@/utils/redux/slices/statsSlice'
 import offlineMutationsReducer from '@/utils/redux/slices/offlineMutationsSlice'
+import * as listenbrainz from '@/api/listenbrainz'
 
 const mockSongsApi = {
   get: jest.fn(),
@@ -139,5 +140,77 @@ describe('scrobble routing', () => {
     const queued = store.getState().offlineMutations.queue
     expect(queued).toHaveLength(1)
     expect(queued[0]).toMatchObject({ type: 'scrobble', songId: 's1', destination: 'server' })
+  })
+})
+
+/**
+ * D1: useScrobbling reads the per-destination route (Disabled /
+ * Through-server / Direct) rather than the old two independent booleans.
+ * These pin the routing decisions the hook makes off that route, including
+ * that ListenBrainz's 'direct' route reaches the ListenBrainz API directly
+ * while never also calling the server adapter for that same destination.
+ */
+describe('scrobble route dispatch', () => {
+  beforeEach(() => { jest.clearAllMocks() })
+
+  it('routes to the server adapter when listenbrainz route is through-server', async () => {
+    const server = serverOf('navidrome')
+    const store = makeStore(server)
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'listenbrainz', route: 'through-server' }))
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'lastfm', route: 'disabled' }))
+
+    const { result } = await renderHook(() => useScrobbling(), { wrapper: wrapperFor(store) })
+    await act(async () => {
+      await result.current.scrobbleIfNeeded(song, { listenedSeconds: 180, startTime: 1_700_000_000 })
+    })
+
+    expect(mockSongsApi.scrobble).toHaveBeenCalledWith('s1', 1_700_000_000)
+  })
+
+  it('routes nothing when both destinations are disabled', async () => {
+    const server = serverOf('navidrome')
+    const store = makeStore(server)
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'listenbrainz', route: 'disabled' }))
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'lastfm', route: 'disabled' }))
+
+    const { result } = await renderHook(() => useScrobbling(), { wrapper: wrapperFor(store) })
+    await act(async () => {
+      await result.current.scrobbleIfNeeded(song, { listenedSeconds: 180, startTime: 1_700_000_000 })
+    })
+
+    expect(mockSongsApi.scrobble).not.toHaveBeenCalled()
+  })
+
+  it('a lastfm route of through-server also drives the server adapter, with no direct option ever offered for it', async () => {
+    const server = serverOf('navidrome')
+    const store = makeStore(server)
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'lastfm', route: 'through-server' }))
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'listenbrainz', route: 'disabled' }))
+
+    const { result } = await renderHook(() => useScrobbling(), { wrapper: wrapperFor(store) })
+    await act(async () => {
+      await result.current.scrobbleIfNeeded(song, { listenedSeconds: 180, startTime: 1_700_000_000 })
+    })
+
+    expect(mockSongsApi.scrobble).toHaveBeenCalledWith('s1', 1_700_000_000)
+    // ScrobbleRoute type has no 'direct' value usable for 'lastfm' — enforced
+    // at the type level, not just by this test's absence of a dispatch.
+  })
+
+  it('routes to ListenBrainz directly, and never also to the server, when its route is direct', async () => {
+    const server = serverOf('navidrome')
+    const store = makeStore(server)
+    store.dispatch(setUsername({ serverId: server.id, value: 'ari' }))
+    store.dispatch(setToken({ serverId: server.id, value: 'tok' }))
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'listenbrainz', route: 'direct' }))
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'lastfm', route: 'disabled' }))
+
+    const { result } = await renderHook(() => useScrobbling(), { wrapper: wrapperFor(store) })
+    await act(async () => {
+      await result.current.scrobbleIfNeeded(song, { listenedSeconds: 180, startTime: 1_700_000_000 })
+    })
+
+    expect(listenbrainz.submitScrobble).toHaveBeenCalled()
+    expect(mockSongsApi.scrobble).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/useScrobbling.ts
+++ b/src/hooks/useScrobbling.ts
@@ -12,11 +12,11 @@ import { canScrobble } from '@/utils/playback/contentKind';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import {
   selectListenBrainzConfig,
-  selectListenBrainzScrobbleEnabled,
 } from '@/utils/redux/selectors/listenbrainzSelectors';
 import {
-  selectServerScrobbleEnabled,
-} from '@/utils/redux/selectors/settingsSelectors';
+  selectLastfmScrobbleRoute,
+  selectListenBrainzScrobbleRoute,
+} from '@/utils/redux/selectors/scrobbleRoutingSelectors';
 import { useApi } from '@/api';
 
 function passesScrobbleThreshold(listenedSeconds: number, durationSeconds: number): boolean {
@@ -30,10 +30,20 @@ export function useScrobbling() {
   const dispatch = useDispatch();
   const activeServer = useSelector(selectActiveServer);
   const listenBrainzConfig = useSelector(selectListenBrainzConfig);
-  // Now-playing is not its own toggle — it follows scrobble. See the note
-  // on selectServerNowPlayingEnabled in settingsSelectors.
-  const lbScrobbleEnabled = useSelector(selectListenBrainzScrobbleEnabled);
-  const serverScrobbleEnabled = useSelector(selectServerScrobbleEnabled);
+  // One route per destination, not two independent booleans — see
+  // scrobbleRoutingSelectors. 'through-server' on either destination is what
+  // used to be `serverScrobbleEnabled`; ListenBrainz's own 'direct' route is
+  // what used to be its per-server scrobble toggle. Now-playing follows
+  // scrobble the same way it always did: whichever route is active for a
+  // destination also drives that destination's now-playing broadcast.
+  const lastfmRoute = useSelector(selectLastfmScrobbleRoute);
+  const listenBrainzRoute = useSelector(selectListenBrainzScrobbleRoute);
+  // The server adapter call covers both "forward to Last.fm" and "forward to
+  // ListenBrainz" server-side — it is one call regardless of which
+  // destination the server is configured to relay to. So it fires whenever
+  // *either* destination is routed 'through-server'.
+  const serverScrobbleEnabled = lastfmRoute === 'through-server' || listenBrainzRoute === 'through-server';
+  const lbScrobbleEnabled = listenBrainzRoute === 'direct';
 
   const lastScrobbledIdRef = useRef<string | null>(null);
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -165,6 +165,14 @@
       "homeSourcesDeezer": "Deezer",
       "homeSourcesDeezerSubtext": "Show Deezer discovery shelves (charts, top tracks, similar artists)."
     },
+    "lyrics": {
+      "title": "Lyrics",
+      "order": "Fallback order",
+      "serverEmbedded": "Server-embedded",
+      "serverEmbeddedSubtext": "Always checked first — the lyrics your server already has for a track.",
+      "lrclib": "LRCLIB",
+      "lrclibSubtext": "Free, anonymous lyrics lookup. Off by default; enable to use it when your server has none."
+    },
     "library": {
       "title": "Library",
       "librarySelect": {
@@ -474,7 +482,12 @@
       "scrobbleDescription": "Log completed tracks to your profile.",
       "nowPlayingDescription": "Show what you're listening to in real time.",
       "markAsPlayed": "Mark as Played",
-      "markAsPlayedDescription": "Update play count on your server."
+      "markAsPlayedDescription": "Update play count on your server.",
+      "routeDisabled": "Disabled",
+      "routeDirect": "Direct from Yuzic",
+      "throughServer": "Through the server",
+      "throughServerMarkAsPlayed": "Through the server (mark as played)",
+      "duplicateRiskNote": "Yuzic can't confirm the server actually forwards scrobbles once \"Through the server\" is selected. If the server is also configured to send scrobbles on its own, or another app scrobbles the same account, plays may be counted twice."
     },
     "home": {
       "title": "Home"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -173,6 +173,27 @@
       "lrclib": "LRCLIB",
       "lrclibSubtext": "Free, anonymous lyrics lookup. Off by default; enable to use it when your server has none."
     },
+    "search": {
+      "title": "Search",
+      "sourcesSection": "Search sources",
+      "explanation": "Which sources the \"Other sources\" scope on the Search screen may query. Independent of Home — enabling a source's Home shelves does not enable it for search, and vice versa.",
+      "deezer": "Deezer",
+      "deezerSubtext": "Include Deezer albums and artists when searching Other sources.",
+      "musicbrainz": "MusicBrainz",
+      "musicbrainzSubtext": "Include MusicBrainz albums and artists when searching Other sources."
+    },
+    "metadata": {
+      "title": "Metadata",
+      "explanation": "Display-only. Fills in artist info and artwork your server doesn't have — it never changes anything on your server, and never writes tags or files. Turn a source off to go back to exactly what your server shows.",
+      "artistInfoSection": "Artist information",
+      "artworkSection": "Artwork",
+      "lastfm": "Last.fm",
+      "lastfmSubtext": "Artist biography and tags. Off by default; enable to use it when your server has no biography.",
+      "deezerArtwork": "Deezer",
+      "deezerArtworkSubtext": "Artist images. Off by default; enable to use it when your server has no artist photo.",
+      "coverArtArchive": "Cover Art Archive",
+      "coverArtArchiveSubtext": "Album covers via MusicBrainz ID. Off by default; enable to use it when your server has no cover."
+    },
     "library": {
       "title": "Library",
       "librarySelect": {
@@ -759,6 +780,16 @@
     "clearRecent": "Clear",
     "removeRecentSearch": "Remove \"{{query}}\" from recent searches",
     "recentlyOpened": "Recently opened",
+    "scope": {
+      "library": "Your Library",
+      "other": "Other sources"
+    },
+    "filters": {
+      "title": "Filters",
+      "sources": "Sources",
+      "entityTypes": "Include",
+      "noSourcesEnabled": "No search sources are enabled. Turn one on in Settings › Search."
+    },
     "entityTypes": {
       "song": "Song",
       "album": "Album",
@@ -777,7 +808,8 @@
       "topSongs": "Top songs"
     },
     "showMore": "{{count}} more",
-    "showUnowned": "{{count}} you don't own"
+    "showUnowned": "{{count}} you don't own",
+    "enrichedBioSource": "via {{source}}"
   },
   "album": {
     "disc": "Disc {{number}}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -173,6 +173,27 @@
       "lrclib": "LRCLIB",
       "lrclibSubtext": "Recherche de paroles gratuite et anonyme. Désactivé par défaut ; activez-le pour l'utiliser quand votre serveur n'en a pas."
     },
+    "search": {
+      "title": "Recherche",
+      "sourcesSection": "Sources de recherche",
+      "explanation": "Quelles sources la portée « Autres sources » de l'écran Recherche peut interroger. Indépendant de l'écran d'accueil — activer les étagères d'une source sur l'accueil ne l'active pas pour la recherche, et inversement.",
+      "deezer": "Deezer",
+      "deezerSubtext": "Inclure les albums et artistes Deezer lors d'une recherche dans Autres sources.",
+      "musicbrainz": "MusicBrainz",
+      "musicbrainzSubtext": "Inclure les albums et artistes MusicBrainz lors d'une recherche dans Autres sources."
+    },
+    "metadata": {
+      "title": "Métadonnées",
+      "explanation": "Affichage uniquement. Complète les informations sur l'artiste et les pochettes que votre serveur n'a pas — cela ne modifie jamais rien sur votre serveur et n'écrit jamais de tags ni de fichiers. Désactivez une source pour revenir exactement à ce que montre votre serveur.",
+      "artistInfoSection": "Informations sur l'artiste",
+      "artworkSection": "Pochettes",
+      "lastfm": "Last.fm",
+      "lastfmSubtext": "Biographie et tags de l'artiste. Désactivé par défaut ; activez-le pour l'utiliser quand votre serveur n'a pas de biographie.",
+      "deezerArtwork": "Deezer",
+      "deezerArtworkSubtext": "Images d'artiste. Désactivé par défaut ; activez-le pour l'utiliser quand votre serveur n'a pas de photo d'artiste.",
+      "coverArtArchive": "Cover Art Archive",
+      "coverArtArchiveSubtext": "Pochettes d'album via l'identifiant MusicBrainz. Désactivé par défaut ; activez-le pour l'utiliser quand votre serveur n'a pas de pochette."
+    },
     "library": {
       "title": "Bibliothèque",
       "librarySelect": {
@@ -759,6 +780,16 @@
     "clearRecent": "Effacer",
     "removeRecentSearch": "Supprimer « {{query}} » des recherches récentes",
     "recentlyOpened": "Ouverts récemment",
+    "scope": {
+      "library": "Votre bibliothèque",
+      "other": "Autres sources"
+    },
+    "filters": {
+      "title": "Filtres",
+      "sources": "Sources",
+      "entityTypes": "Inclure",
+      "noSourcesEnabled": "Aucune source de recherche n'est activée. Activez-en une dans Réglages › Recherche."
+    },
     "entityTypes": {
       "song": "Titre",
       "album": "Album",
@@ -787,7 +818,8 @@
       "topSongs": "Titres populaires"
     },
     "showMore": "{{count}} de plus",
-    "showUnowned": "{{count}} que vous ne possédez pas"
+    "showUnowned": "{{count}} que vous ne possédez pas",
+    "enrichedBioSource": "via {{source}}"
   },
   "explore": {
     "sections": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -165,6 +165,14 @@
       "homeSourcesDeezer": "Deezer",
       "homeSourcesDeezerSubtext": "Afficher les rayons de découverte Deezer (classements, titres phares, artistes similaires)."
     },
+    "lyrics": {
+      "title": "Paroles",
+      "order": "Ordre de repli",
+      "serverEmbedded": "Intégrées au serveur",
+      "serverEmbeddedSubtext": "Toujours vérifiées en premier — les paroles que votre serveur possède déjà pour un titre.",
+      "lrclib": "LRCLIB",
+      "lrclibSubtext": "Recherche de paroles gratuite et anonyme. Désactivé par défaut ; activez-le pour l'utiliser quand votre serveur n'en a pas."
+    },
     "library": {
       "title": "Bibliothèque",
       "librarySelect": {
@@ -474,7 +482,12 @@
       "scrobbleDescription": "Enregistrer les titres écoutés sur votre profil.",
       "nowPlayingDescription": "Afficher ce que vous écoutez en temps réel.",
       "markAsPlayed": "Marquer comme écouté",
-      "markAsPlayedDescription": "Mettre à jour le nombre de lectures sur votre serveur."
+      "markAsPlayedDescription": "Mettre à jour le nombre de lectures sur votre serveur.",
+      "routeDisabled": "Désactivé",
+      "routeDirect": "Direct depuis Yuzic",
+      "throughServer": "Via le serveur",
+      "throughServerMarkAsPlayed": "Via le serveur (marquer comme écouté)",
+      "duplicateRiskNote": "Yuzic ne peut pas confirmer que le serveur transmet réellement les scrobbles une fois « Via le serveur » sélectionné. Si le serveur est aussi configuré pour envoyer des scrobbles de son côté, ou qu'une autre application scrobble le même compte, les écoutes peuvent être comptées deux fois."
     },
     "home": {
       "title": "Accueil"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -173,6 +173,27 @@
       "lrclib": "LRCLIB",
       "lrclibSubtext": "無料・匿名の歌詞検索。デフォルトではオフ。サーバーに歌詞がない場合に使うには有効にしてください。"
     },
+    "search": {
+      "title": "検索",
+      "sourcesSection": "検索ソース",
+      "explanation": "検索画面の「その他のソース」スコープが問い合わせるソース。ホームとは独立しています — ホームの棚を有効にしても検索が有効になるわけではなく、その逆も同様です。",
+      "deezer": "Deezer",
+      "deezerSubtext": "「その他のソース」での検索に Deezer のアルバムとアーティストを含めます。",
+      "musicbrainz": "MusicBrainz",
+      "musicbrainzSubtext": "「その他のソース」での検索に MusicBrainz のアルバムとアーティストを含めます。"
+    },
+    "metadata": {
+      "title": "メタデータ",
+      "explanation": "表示のみです。サーバーにないアーティスト情報やアートワークを補完します — サーバー上の何かを変更したり、タグやファイルを書き込んだりすることは一切ありません。ソースをオフにすると、サーバーが表示する内容そのものに戻ります。",
+      "artistInfoSection": "アーティスト情報",
+      "artworkSection": "アートワーク",
+      "lastfm": "Last.fm",
+      "lastfmSubtext": "アーティストの経歴とタグ。デフォルトではオフ。サーバーに経歴がない場合に使うには有効にしてください。",
+      "deezerArtwork": "Deezer",
+      "deezerArtworkSubtext": "アーティスト画像。デフォルトではオフ。サーバーにアーティスト写真がない場合に使うには有効にしてください。",
+      "coverArtArchive": "Cover Art Archive",
+      "coverArtArchiveSubtext": "MusicBrainz IDによるアルバムカバー。デフォルトではオフ。サーバーにカバーがない場合に使うには有効にしてください。"
+    },
     "library": {
       "title": "ライブラリ",
       "librarySelect": {
@@ -756,6 +777,16 @@
     "clearRecent": "クリア",
     "removeRecentSearch": "「{{query}}」を最近の検索から削除",
     "recentlyOpened": "最近開いた項目",
+    "scope": {
+      "library": "ライブラリ",
+      "other": "その他のソース"
+    },
+    "filters": {
+      "title": "フィルター",
+      "sources": "ソース",
+      "entityTypes": "対象",
+      "noSourcesEnabled": "検索ソースが有効になっていません。設定 › 検索 で有効にしてください。"
+    },
     "entityTypes": {
       "song": "曲",
       "album": "アルバム",
@@ -784,7 +815,8 @@
       "topSongs": "人気の曲"
     },
     "showMore": "あと{{count}}件",
-    "showUnowned": "未所持の{{count}}件"
+    "showUnowned": "未所持の{{count}}件",
+    "enrichedBioSource": "{{source}}より"
   },
   "explore": {
     "sections": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -165,6 +165,14 @@
       "homeSourcesDeezer": "Deezer",
       "homeSourcesDeezerSubtext": "Deezer のディスカバリー棚（チャート、人気曲、類似アーティスト）を表示します。"
     },
+    "lyrics": {
+      "title": "歌詞",
+      "order": "フォールバック順序",
+      "serverEmbedded": "サーバー内蔵",
+      "serverEmbeddedSubtext": "常に最初に確認されます — サーバーがすでに持っている曲の歌詞です。",
+      "lrclib": "LRCLIB",
+      "lrclibSubtext": "無料・匿名の歌詞検索。デフォルトではオフ。サーバーに歌詞がない場合に使うには有効にしてください。"
+    },
     "library": {
       "title": "ライブラリ",
       "librarySelect": {
@@ -473,7 +481,12 @@
       "scrobbleDescription": "再生済みトラックをプロフィールに記録する。",
       "nowPlayingDescription": "再生中の曲をリアルタイムで表示する。",
       "markAsPlayed": "再生済みにする",
-      "markAsPlayedDescription": "サーバーの再生回数を更新します。"
+      "markAsPlayedDescription": "サーバーの再生回数を更新します。",
+      "routeDisabled": "無効",
+      "routeDirect": "Yuzicから直接",
+      "throughServer": "サーバー経由",
+      "throughServerMarkAsPlayed": "サーバー経由(再生済みにする)",
+      "duplicateRiskNote": "「サーバー経由」を選択しても、Yuzicはサーバーが実際にスクロブルを転送しているかを確認できません。サーバー側でも独自にスクロブルを送信するよう設定されている場合や、同じアカウントで別のアプリがスクロブルしている場合、再生が二重に記録されることがあります。"
     },
     "home": {
       "title": "ホーム"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -165,6 +165,14 @@
       "homeSourcesDeezer": "Deezer",
       "homeSourcesDeezerSubtext": "显示 Deezer 的发现栏目（排行榜、热门单曲、相似艺人）。"
     },
+    "lyrics": {
+      "title": "歌词",
+      "order": "回退顺序",
+      "serverEmbedded": "服务器内嵌",
+      "serverEmbeddedSubtext": "始终最先检查 —— 服务器上已有的这首歌的歌词。",
+      "lrclib": "LRCLIB",
+      "lrclibSubtext": "免费、匿名的歌词查询。默认关闭；当服务器没有歌词时可开启使用。"
+    },
     "library": {
       "title": "媒体库",
       "librarySelect": {
@@ -473,7 +481,12 @@
       "scrobbleDescription": "将已播放的曲目记录到你的个人资料。",
       "nowPlayingDescription": "实时显示正在播放的内容。",
       "markAsPlayed": "标记为已播放",
-      "markAsPlayedDescription": "更新服务器上的播放次数。"
+      "markAsPlayedDescription": "更新服务器上的播放次数。",
+      "routeDisabled": "已禁用",
+      "routeDirect": "由 Yuzic 直接发送",
+      "throughServer": "通过服务器",
+      "throughServerMarkAsPlayed": "通过服务器(标记为已播放)",
+      "duplicateRiskNote": "选择“通过服务器”后,Yuzic 无法确认服务器是否真的会转发 scrobble。如果服务器同时也配置了自己发送 scrobble,或另一个应用对同一账号进行 scrobble,播放记录可能会被重复计算。"
     },
     "home": {
       "title": "主页"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -173,6 +173,27 @@
       "lrclib": "LRCLIB",
       "lrclibSubtext": "免费、匿名的歌词查询。默认关闭；当服务器没有歌词时可开启使用。"
     },
+    "search": {
+      "title": "搜索",
+      "sourcesSection": "搜索来源",
+      "explanation": "搜索页面「其他来源」范围可以查询的来源。与首页相互独立 —— 为某个来源开启首页栏目不会为搜索开启它,反之亦然。",
+      "deezer": "Deezer",
+      "deezerSubtext": "在「其他来源」中搜索时包含 Deezer 的专辑和艺人。",
+      "musicbrainz": "MusicBrainz",
+      "musicbrainzSubtext": "在「其他来源」中搜索时包含 MusicBrainz 的专辑和艺人。"
+    },
+    "metadata": {
+      "title": "元数据",
+      "explanation": "仅用于显示。补充服务器没有的艺术家信息和封面 —— 绝不会更改服务器上的任何内容,也绝不会写入标签或文件。关闭某个来源即可恢复到服务器原本显示的内容。",
+      "artistInfoSection": "艺术家信息",
+      "artworkSection": "封面",
+      "lastfm": "Last.fm",
+      "lastfmSubtext": "艺术家简介和标签。默认关闭;当服务器没有简介时可开启使用。",
+      "deezerArtwork": "Deezer",
+      "deezerArtworkSubtext": "艺术家图片。默认关闭;当服务器没有艺术家照片时可开启使用。",
+      "coverArtArchive": "Cover Art Archive",
+      "coverArtArchiveSubtext": "通过 MusicBrainz ID 获取专辑封面。默认关闭;当服务器没有封面时可开启使用。"
+    },
     "library": {
       "title": "媒体库",
       "librarySelect": {
@@ -756,6 +777,16 @@
     "clearRecent": "清除",
     "removeRecentSearch": "从最近搜索中删除“{{query}}”",
     "recentlyOpened": "最近打开",
+    "scope": {
+      "library": "音乐库",
+      "other": "其他来源"
+    },
+    "filters": {
+      "title": "筛选",
+      "sources": "来源",
+      "entityTypes": "包含",
+      "noSourcesEnabled": "尚未启用任何搜索来源。请在 设置 › 搜索 中启用一个。"
+    },
     "entityTypes": {
       "song": "歌曲",
       "album": "专辑",
@@ -784,7 +815,8 @@
       "topSongs": "热门歌曲"
     },
     "showMore": "还有 {{count}} 个",
-    "showUnowned": "你未拥有的 {{count}} 个"
+    "showUnowned": "你未拥有的 {{count}} 个",
+    "enrichedBioSource": "来自 {{source}}"
   },
   "explore": {
     "sections": {

--- a/src/screens/artist/components/Content/BioSection.tsx
+++ b/src/screens/artist/components/Content/BioSection.tsx
@@ -7,12 +7,20 @@ import { spacing, typography } from '@/constants/design'
 
 type Props = {
   biography?: string
+  /**
+   * Set only when `biography` came from `metadata.enrich` rather than the
+   * server/Deezer — draws a small unobtrusive source line under the bio
+   * ("via Last.fm"), never a persistent per-item badge. Display-only: this
+   * has no bearing on whether the bio is shown, only on how it's credited.
+   */
+  enrichedSourceLabel?: string | null
 }
 
 // The biography always comes from an external source (Deezer in local mode,
 // the resolved external artist otherwise) — self-hosted servers don't carry
-// artist biography text.
-export default function BioSection({ biography }: Props) {
+// artist biography text — or, when metadata enrichment is on and neither of
+// those has one, from a metadata.enrich source (see `features/metadata`).
+export default function BioSection({ biography, enrichedSourceLabel }: Props) {
   const { colors } = useTheme()
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
@@ -39,6 +47,11 @@ export default function BioSection({ biography }: Props) {
         <Text style={[styles.bioToggle, { color: colors.subtext }]}>
           {expanded ? t('common.less') : t('common.more')}
         </Text>
+        {enrichedSourceLabel && (
+          <Text style={[styles.sourceLine, { color: colors.subtext }]}>
+            {t('artist.enrichedBioSource', { source: enrichedSourceLabel })}
+          </Text>
+        )}
       </Touchable>
     </View>
   )
@@ -64,5 +77,9 @@ const styles = StyleSheet.create({
     ...typography.caption,
     fontWeight: '500',
     marginTop: spacing.xs,
+  },
+  sourceLine: {
+    ...typography.micro,
+    marginTop: spacing.xxs,
   },
 })

--- a/src/screens/artist/components/Content/index.tsx
+++ b/src/screens/artist/components/Content/index.tsx
@@ -25,6 +25,7 @@ import MediaTile from '@/screens/home/components/MediaTile'
 import MostPlayedSection from './MostPlayedSection'
 import PopularOnDeezerSection from './PopularOnDeezerSection'
 import BioSection from './BioSection'
+import { useArtistInfoEnrichment } from '@/features/metadata/useArtistInfoEnrichment'
 import { findArtistsWithSharedGenres, type LocalArtistSummary } from './localSimilarArtists'
 import { useMatchedNavigation } from '@/features/sources/useMatchedNavigation'
 import { useDeezerDiscoveryEnabled } from '@/features/home/hooks/useDeezerEnabled'
@@ -493,6 +494,11 @@ function PopularOnDeezerSectionResolver({ localArtist, externalArtist }: {
 // above runs, so react-query dedupes it), external mode already has it on
 // the artist. Gated by the Deezer Top Tracks setting in local mode, matching
 // the pre-unification behavior where the bio lived inside TopTracksSection.
+//
+// When neither source has a bio, `useArtistInfoEnrichment` (metadata.enrich,
+// GAPS ONLY — see features/metadata) may fill the gap; it stays a no-op
+// whenever a real bio already exists, so this never overrides server/Deezer
+// data, only supplements its absence.
 function BioSectionResolver({ localArtist, externalArtist }: {
   localArtist: Artist | null
   externalArtist: ExternalArtist | null
@@ -504,7 +510,22 @@ function BioSectionResolver({ localArtist, externalArtist }: {
     enabled: !!localArtist && deezerEnabled,
   })
 
-  return <BioSection biography={localArtist ? localBiography : externalArtist?.biography} />
+  const ownBio = localArtist ? localBiography : externalArtist?.biography
+  const artistName = localArtist?.name ?? externalArtist?.name ?? ''
+  const artistMbid = localArtist?.mbid ?? externalArtist?.externalIds?.mbid ?? null
+
+  const { bio: enrichedBio, sourceLabel } = useArtistInfoEnrichment({
+    name: artistName,
+    mbid: artistMbid,
+    hasOwnBio: !!ownBio,
+  })
+
+  return (
+    <BioSection
+      biography={ownBio ?? enrichedBio ?? undefined}
+      enrichedSourceLabel={ownBio ? null : sourceLabel}
+    />
+  )
 }
 
 const styles = StyleSheet.create({

--- a/src/screens/playing/index.tsx
+++ b/src/screens/playing/index.tsx
@@ -11,7 +11,9 @@ import { usePlayingState, usePlayingProgress } from '@/contexts/PlayingContext';
 import { useRouter } from 'expo-router';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { selectShowSleepTimer, selectShowPlaybackSpeed, selectShowVolumeSlider } from '@/utils/redux/selectors/settingsSelectors';
+import { selectShowSleepTimer, selectShowPlaybackSpeed, selectShowVolumeSlider, selectEnabledLyricsExternalSourcesInOrder } from '@/utils/redux/selectors/settingsSelectors';
+import { resolveLyrics, ALL_EXTERNAL_LYRICS_SOURCES, type ExternalLyricsSourceId } from '@/features/lyrics/resolveLyrics';
+import { externalLyricsFetchers } from '@/features/lyrics/externalLyricsFetchers';
 import SongOptions from '@/components/options/SongOptions';
 import Queue from './components/Queue';
 import Animated, {
@@ -215,6 +217,17 @@ const PlayingScreen: React.FC<PlayingScreenProps> = ({
         [dragMoved, expansion, height, scrollY],
     );
 
+    const enabledExternalLyricsSourceIds = useSelector(selectEnabledLyricsExternalSourcesInOrder);
+    // The redux slice stores plain strings so it never has to know about this
+    // union; narrow to the ids the resolver actually recognises here, at the
+    // one place that reads it.
+    const enabledExternalLyricsSources = useMemo(
+        () => enabledExternalLyricsSourceIds.filter(
+            (id): id is ExternalLyricsSourceId => (ALL_EXTERNAL_LYRICS_SOURCES as string[]).includes(id)
+        ),
+        [enabledExternalLyricsSourceIds]
+    );
+
     useEffect(() => {
         if (!currentSong?.id) return;
 
@@ -225,7 +238,18 @@ const PlayingScreen: React.FC<PlayingScreenProps> = ({
         const task = InteractionManager.runAfterInteractions(() => {
             (async () => {
                 try {
-                    const res = await api.lyrics.getBySongId(currentSong.id);
+                    const res = await resolveLyrics({
+                        song: {
+                            songId: currentSong.id,
+                            title: currentSong.title,
+                            artist: currentSong.artist,
+                            album: currentSong.albumTitle,
+                            durationSec: Number(currentSong.duration) || undefined,
+                        },
+                        getServerLyrics: songId => api.lyrics.getBySongId(songId),
+                        enabledExternalSourcesInOrder: enabledExternalLyricsSources,
+                        fetchers: externalLyricsFetchers,
+                    });
                     if (cancelled) return;
                     if (res && res.lines.length > 0) {
                         setLyrics(res);
@@ -243,7 +267,7 @@ const PlayingScreen: React.FC<PlayingScreenProps> = ({
             cancelled = true;
             task.cancel();
         };
-    }, [api.lyrics, currentSong?.id]);
+    }, [api.lyrics, currentSong?.id, currentSong?.title, currentSong?.artist, currentSong?.albumTitle, currentSong?.duration, enabledExternalLyricsSources]);
 
     const showSleepTimer = useSelector(selectShowSleepTimer);
     const showPlaybackSpeed = useSelector(selectShowPlaybackSpeed);

--- a/src/screens/search/components/SearchFiltersSheet.tsx
+++ b/src/screens/search/components/SearchFiltersSheet.tsx
@@ -1,0 +1,119 @@
+import React, { forwardRef, useMemo } from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { Check } from 'lucide-react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '@/hooks/useTheme';
+import { renderBackdrop } from '@/components/BottomSheetBackdrop';
+import {
+  OptionSheetDivider,
+  OptionSheetRow,
+  OptionSheetSectionLabel,
+  optionSheetStyles,
+  useOptionSheetBackground,
+} from '@/components/options/OptionSheetPrimitives';
+import { getSourceMeta, type SourceId } from '@/features/sources/registry';
+import { iconSize, spacing, typography } from '@/constants/design';
+import type { SearchEntityType } from '@/contexts/SearchContext';
+
+type Props = {
+  /** Sources enabled for search at all — the sheet only ever offers these;
+   *  a source turned off in Settings never appears here to be re-enabled
+   *  per-search. */
+  availableSourceIds: SourceId[];
+  selectedSourceIds: string[];
+  onToggleSource: (sourceId: SourceId) => void;
+  selectedEntityTypes: SearchEntityType[];
+  onToggleEntityType: (entityType: SearchEntityType) => void;
+};
+
+const ENTITY_TYPE_ORDER: SearchEntityType[] = ['album', 'artist'];
+
+/**
+ * The Filters sheet behind "Other sources" — picks which enabled search
+ * sources and which entity types are included in the current external
+ * search. Distinct from the Search settings screen: that decides which
+ * sources are *available* for search at all; this decides which of those
+ * are in play for *this* search.
+ */
+const SearchFiltersSheet = forwardRef<BottomSheetModal, Props>(
+  ({ availableSourceIds, selectedSourceIds, onToggleSource, selectedEntityTypes, onToggleEntityType }, ref) => {
+    const { t } = useTranslation();
+    const { colors } = useTheme();
+    const sheetBg = useOptionSheetBackground();
+
+    const entityTypeLabel = (entityType: SearchEntityType) => t(`search.entityTypes.${entityType}`);
+
+    const snapPoints = useMemo(() => ['50%'], []);
+
+    return (
+      <BottomSheetModal
+        ref={ref}
+        snapPoints={snapPoints}
+        enableDynamicSizing={false}
+        enablePanDownToClose
+        backdropComponent={renderBackdrop}
+        handleIndicatorStyle={{ backgroundColor: colors.border }}
+        backgroundStyle={[optionSheetStyles.sheetBackground, sheetBg]}
+      >
+        <BottomSheetScrollView style={sheetBg} contentContainerStyle={optionSheetStyles.sheetContent}>
+          <Text style={[styles.title, { color: colors.secondary }]}>
+            {t('search.filters.title')}
+          </Text>
+
+          <OptionSheetSectionLabel label={t('search.filters.sources')} />
+          {availableSourceIds.length === 0 && (
+            <Text style={[styles.empty, { color: colors.subtext }]} testID="search-filters-no-sources">
+              {t('search.filters.noSourcesEnabled')}
+            </Text>
+          )}
+          {availableSourceIds.map(sourceId => {
+            const meta = getSourceMeta(sourceId);
+            const checked = selectedSourceIds.includes(sourceId);
+            return (
+              <OptionSheetRow
+                key={sourceId}
+                testID={`search-filters-source-${sourceId}`}
+                label={meta?.label ?? sourceId}
+                onPress={() => onToggleSource(sourceId)}
+                trailing={checked ? <Check size={iconSize.secondary} color={colors.themeColor} /> : undefined}
+              />
+            );
+          })}
+
+          <OptionSheetDivider />
+
+          <OptionSheetSectionLabel label={t('search.filters.entityTypes')} />
+          {ENTITY_TYPE_ORDER.map(entityType => {
+            const checked = selectedEntityTypes.includes(entityType);
+            return (
+              <OptionSheetRow
+                key={entityType}
+                testID={`search-filters-entity-${entityType}`}
+                label={entityTypeLabel(entityType)}
+                onPress={() => onToggleEntityType(entityType)}
+                trailing={checked ? <Check size={iconSize.secondary} color={colors.themeColor} /> : undefined}
+              />
+            );
+          })}
+        </BottomSheetScrollView>
+      </BottomSheetModal>
+    );
+  }
+);
+
+SearchFiltersSheet.displayName = 'SearchFiltersSheet';
+
+export default SearchFiltersSheet;
+
+const styles = StyleSheet.create({
+  title: {
+    ...typography.rowTitle,
+    fontWeight: '600',
+    marginBottom: spacing.md,
+  },
+  empty: {
+    ...typography.caption,
+    marginBottom: spacing.sm,
+  },
+});

--- a/src/screens/search/components/SearchScopeControl.tsx
+++ b/src/screens/search/components/SearchScopeControl.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '@/hooks/useTheme';
+import Touchable from '@/components/Touchable';
+import { radius, spacing, typography } from '@/constants/design';
+import { useRadius } from '@/hooks/useRadius';
+import type { SearchResultScope } from '@/contexts/searchLegs';
+
+type Props = {
+  value: SearchResultScope;
+  onChange: (value: SearchResultScope) => void;
+};
+
+/**
+ * Your Library / Other sources — the top-level scope choice for Search.
+ *
+ * "Your Library" is the default and is what always runs on load: today's
+ * local (and, per the scope setting, server) search, no external calls.
+ * "Other sources" is a deliberate, separate action the user takes to reach
+ * outside the library — it never runs unless picked, which is what keeps
+ * library and external results from mixing without being asked for.
+ */
+export default function SearchScopeControl({ value, onChange }: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const rad = useRadius();
+
+  const options: { key: SearchResultScope; label: string; testID: string }[] = [
+    { key: 'library', label: t('search.scope.library'), testID: 'search-scope-library' },
+    { key: 'other', label: t('search.scope.other'), testID: 'search-scope-other' },
+  ];
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.muted, borderRadius: rad.md }]}
+      testID="search-scope-control"
+    >
+      {options.map(option => {
+        const active = option.key === value;
+        return (
+          <Touchable
+            key={option.key}
+            testID={option.testID}
+            accessibilityRole="button"
+            accessibilityState={{ selected: active }}
+            onPress={() => onChange(option.key)}
+            style={[
+              styles.segment,
+              { borderRadius: radius.sm, backgroundColor: active ? colors.card : 'transparent' },
+            ]}
+          >
+            <Text
+              style={[
+                styles.segmentText,
+                { color: active ? colors.secondary : colors.subtext },
+                active && styles.segmentTextActive,
+              ]}
+            >
+              {option.label}
+            </Text>
+          </Touchable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    padding: spacing.xxs,
+  },
+  segment: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.xs,
+  },
+  segmentText: {
+    ...typography.rowSubtitle,
+  },
+  segmentTextActive: {
+    fontWeight: '600',
+  },
+});

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   TextInput,
@@ -7,11 +7,13 @@ import {
   ScrollView,
   Text,
 } from 'react-native';
-import { CloudOff, Ellipsis, Search as SearchIcon, X } from 'lucide-react-native';
+import { CloudOff, Ellipsis, SlidersHorizontal, Search as SearchIcon, X } from 'lucide-react-native';
 import { useFocusEffect, useNavigation, useScrollToTop } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import type { BottomSheetModal } from '@gorhom/bottom-sheet';
 
-import { SearchResult, useSearch } from '@/contexts/SearchContext';
+import { SearchResult, useSearch, ALL_SEARCH_ENTITY_TYPES, type SearchEntityType } from '@/contexts/SearchContext';
+import type { SearchResultScope } from '@/contexts/searchLegs';
 import type { ExternalAlbumBase } from '@/types';
 import AlbumRow from '@/components/rows/AlbumRow';
 import ArtistRow from '@/components/rows/ArtistRow';
@@ -28,7 +30,6 @@ import { toast } from '@backpackapp-io/react-native-toast';
 import { usePrefetchCovers } from '@/hooks/usePrefetchCovers';
 import { prefetchCovers } from '@/utils/images/imageCache';
 import { usePlayableSongResolver } from '@/hooks/songs';
-import { useDeezerSearchEnabled } from '@/features/home/hooks/useDeezerEnabled';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectShowSourceHeaders } from '@/utils/redux/selectors/settingsSelectors';
 import { selectActiveServer, selectActiveServerId } from '@/utils/redux/selectors/serversSelectors';
@@ -44,8 +45,11 @@ import {
   type SearchEntityEntry,
 } from '@/utils/redux/slices/searchHistorySlice';
 import RecentSearches from './components/RecentSearches';
+import SearchScopeControl from './components/SearchScopeControl';
+import SearchFiltersSheet from './components/SearchFiltersSheet';
 import { useMatchedNavigation } from '@/features/sources/useMatchedNavigation';
 import { getSourceMeta } from '@/features/sources/registry';
+import { useEnabledSearchSourceIds } from '@/features/sources/useSearchSourcesEnabled';
 import TabHeader from '@/components/TabHeader';
 import { useAccountSheet } from '@/contexts/AccountSheetContext';
 import Touchable from '@/components/Touchable';
@@ -56,6 +60,7 @@ import { useScrollClearance } from '@/hooks/useScrollClearance';
 const Search = () => {
   const searchInputRef = useRef<TextInput>(null);
   const scrollRef = useRef<ScrollView>(null);
+  const filtersSheetRef = useRef<BottomSheetModal>(null);
   useScrollToTop(scrollRef);
   const { openSongOptions } = useSongActionSheets();
   const navigation = useNavigation<any>();
@@ -67,7 +72,9 @@ const Search = () => {
   const dispatch = useDispatch();
   const { playSong } = usePlayingActions();
   const { resolvePlayableSong } = usePlayableSongResolver();
-  const deezerSearchEnabled = useDeezerSearchEnabled();
+  // Sources the user has turned on FOR SEARCH — independent of Home/discovery
+  // enablement. Nothing here is ever implied by a Home toggle.
+  const enabledSearchSourceIds = useEnabledSearchSourceIds();
   const showSourceHeaders = useSelector(selectShowSourceHeaders);
   const username = useSelector(selectActiveServer)?.username;
   const activeServerId = useSelector(selectActiveServerId);
@@ -77,6 +84,11 @@ const Search = () => {
 
   const [query, setQuery] = useState('');
   const [hasSearched, setHasSearched] = useState(false);
+  // 'library' is the default and the only scope that ever runs without an
+  // explicit switch — "Other sources" is the deliberate external action.
+  const [resultScope, setResultScope] = useState<SearchResultScope>('library');
+  const [selectedSourceIds, setSelectedSourceIds] = useState<string[]>(enabledSearchSourceIds);
+  const [selectedEntityTypes, setSelectedEntityTypes] = useState<SearchEntityType[]>(ALL_SEARCH_ENTITY_TYPES);
   const { searchResults, handleSearchWithFilters, clearSearch, isLoading, hasError, degraded } = useSearch();
 
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -84,6 +96,16 @@ const Search = () => {
   // keystroke but still needs to read the current value.
   const queryRef = useRef(query);
   queryRef.current = query;
+
+  // Mirrors scope/filter selections for the same reason `queryRef` exists:
+  // `runSearch` is stable across re-renders it doesn't need to react to, but
+  // still has to read the current selection when the debounce/submit fires.
+  const scopeRef = useRef(resultScope);
+  scopeRef.current = resultScope;
+  const selectedSourceIdsRef = useRef(selectedSourceIds);
+  selectedSourceIdsRef.current = selectedSourceIds;
+  const selectedEntityTypesRef = useRef(selectedEntityTypes);
+  selectedEntityTypesRef.current = selectedEntityTypes;
 
   /**
    * Open the keyboard when the tab is opened with nothing typed.
@@ -110,7 +132,6 @@ const Search = () => {
       return () => cancelAnimationFrame(frame);
       // Intentionally not reacting to `query`: this fires on focus, and
       // re-running it as the user types would fight the keyboard.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
   );
 
@@ -120,11 +141,38 @@ const Search = () => {
     };
   }, []);
 
-  const runSearch = (text: string) => {
+  // A source that stops being enabled for search (disabled in Settings, or
+  // the device going offline) drops out of the current selection too, so a
+  // stale id never reaches `handleSearchWithFilters`. A newly-enabled source
+  // is not auto-selected, so a user who narrowed the Filters sheet on purpose
+  // doesn't have that choice silently widened out from under them.
+  useEffect(() => {
+    setSelectedSourceIds(prev => {
+      const next = prev.filter(id => enabledSearchSourceIds.includes(id as never));
+      return next.length === prev.length ? prev : next;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabledSearchSourceIds.join(',')]);
+
+  const runSearch = useCallback((text: string) => {
     clearSearch();
     setHasSearched(true);
-    void handleSearchWithFilters(text, { local: true, deezer: deezerSearchEnabled });
-  };
+    void handleSearchWithFilters(text, {
+      resultScope: scopeRef.current,
+      sourceIds: selectedSourceIdsRef.current,
+      entityTypes: selectedEntityTypesRef.current,
+    });
+  }, [clearSearch, handleSearchWithFilters]);
+
+  // Switching scope (or the filters underneath "Other sources") re-runs the
+  // current query immediately rather than waiting for the next keystroke —
+  // otherwise flipping to "Other sources" would show stale library results
+  // (or nothing) until the user typed again.
+  useEffect(() => {
+    if (query.trim() === '') return;
+    runSearch(query);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resultScope, selectedSourceIds.join(','), selectedEntityTypes.join(',')]);
 
   // Only called from deliberate actions (submitting, tapping a result, replaying a
   // recent search) — never from the as-you-type debounce, or every paused keystroke
@@ -267,11 +315,22 @@ const Search = () => {
     }
   };
 
-  const localResults = useMemo(() => searchResults.filter(r => r.source === 'local'), [searchResults]);
+  // The library scope only ever contains local results, and "Other sources"
+  // only ever contains external ones — `resultScope` already kept the fetch
+  // itself from mixing the two (see `planSearchLegs`), and this keeps the
+  // render from doing it either, belt and suspenders against a stray result
+  // slipping in from a stale request.
+  const libraryResults = useMemo(
+    () => (resultScope === 'library' ? searchResults.filter(r => r.source === 'local') : []),
+    [searchResults, resultScope]
+  );
 
-  // Group external results by their source so each gets its own labelled section
+  // Group external results by their source so each gets its own labelled,
+  // provenance-tagged section — never merged into one undifferentiated list,
+  // and never merged with the library results above.
   const externalResultsBySource = useMemo(() => {
     const groups = new Map<string, typeof searchResults>();
+    if (resultScope !== 'other') return groups;
     for (const r of searchResults) {
       if (r.source !== 'external' || !r.externalSource) continue;
       const existing = groups.get(r.externalSource);
@@ -279,13 +338,25 @@ const Search = () => {
       else groups.set(r.externalSource, [r]);
     }
     return groups;
-  }, [searchResults]);
+  }, [searchResults, resultScope]);
 
   const coversToPrefetch = useMemo(
     () => searchResults.slice(0, 18).map(r => r.cover),
     [searchResults]
   );
   usePrefetchCovers(coversToPrefetch, 'thumb');
+
+  const toggleFilterSource = useCallback((sourceId: string) => {
+    setSelectedSourceIds(prev =>
+      prev.includes(sourceId) ? prev.filter(id => id !== sourceId) : [...prev, sourceId]
+    );
+  }, []);
+
+  const toggleFilterEntityType = useCallback((entityType: SearchEntityType) => {
+    setSelectedEntityTypes(prev =>
+      prev.includes(entityType) ? prev.filter(type => type !== entityType) : [...prev, entityType]
+    );
+  }, []);
 
   const renderResult = (result: SearchResult) => {
     if (result.type === 'song') {
@@ -381,6 +452,10 @@ const Search = () => {
     return null;
   };
 
+  const isOtherScope = resultScope === 'other';
+  const noResultsForScope = query.trim() !== '' && hasSearched && !isLoading
+    && (isOtherScope ? externalResultsBySource.size === 0 : libraryResults.length === 0);
+
   return (
     <SafeAreaView testID="search-screen" edges={['top']} style={[styles.container, { backgroundColor: colors.background }]}>
       <TabHeader
@@ -426,6 +501,23 @@ const Search = () => {
         </View>
       </View>
 
+      <View style={styles.scopeRow}>
+        <View style={styles.scopeControlWrap}>
+          <SearchScopeControl value={resultScope} onChange={setResultScope} />
+        </View>
+        {isOtherScope && (
+          <Touchable
+            testID="search-filters-button"
+            accessibilityRole="button"
+            accessibilityLabel={t('search.filters.title')}
+            style={[styles.filtersButton, { backgroundColor: colors.muted, borderRadius: rad.md }]}
+            onPress={() => filtersSheetRef.current?.present()}
+          >
+            <SlidersHorizontal size={iconSize.row} color={colors.secondary} />
+          </Touchable>
+        )}
+      </View>
+
       {hasSearched && !isLoading && (hasError || degraded) && (
         <StatusBanner
           icon={<CloudOff size={iconSize.badge} color={colors.subtext} />}
@@ -463,13 +555,13 @@ const Search = () => {
             ? [...Array(8)].map((_, i) => <SkeletonListRow key={i} />)
             : (
               <>
-                {localResults.map(result => (
+                {!isOtherScope && libraryResults.map(result => (
                   <View key={`local:${result.type}:${result.id}`} style={styles.resultBlock}>
                     {renderResult(result)}
                   </View>
                 ))}
 
-                {Array.from(externalResultsBySource.entries()).map(([sourceId, results]) => {
+                {isOtherScope && Array.from(externalResultsBySource.entries()).map(([sourceId, results]) => {
                   const meta = getSourceMeta(sourceId);
                   const label = meta?.label ?? sourceId;
                   const color = meta?.color ?? colors.subtext;
@@ -496,12 +588,21 @@ const Search = () => {
             )
         }
 
-        {query.trim() !== '' && hasSearched && !isLoading && searchResults.length === 0 && (
+        {noResultsForScope && (
           <Text testID="search-no-results" style={[styles.noResults, { color: colors.subtext }]}>
             {t('search.noResults')}
           </Text>
         )}
       </ScrollView>
+
+      <SearchFiltersSheet
+        ref={filtersSheetRef}
+        availableSourceIds={enabledSearchSourceIds}
+        selectedSourceIds={selectedSourceIds}
+        onToggleSource={toggleFilterSource}
+        selectedEntityTypes={selectedEntityTypes}
+        onToggleEntityType={toggleFilterEntityType}
+      />
     </SafeAreaView>
   );
 };
@@ -536,6 +637,22 @@ const styles = StyleSheet.create({
     padding: spacing.xs,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  scopeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.sm,
+  },
+  scopeControlWrap: {
+    flex: 1,
+  },
+  filtersButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   errorBanner: {
     marginHorizontal: spacing.lg,

--- a/src/screens/settings/home/index.tsx
+++ b/src/screens/settings/home/index.tsx
@@ -8,7 +8,7 @@ import {
     Linking,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Server, Library, Volume2, Palette, Puzzle, CloudDownload, Github, ShieldCheck, ScrollText, House as HomeIcon } from 'lucide-react-native';
+import { Server, Library, Volume2, Palette, Puzzle, CloudDownload, Github, ShieldCheck, ScrollText, House as HomeIcon, Mic2, Disc3 } from 'lucide-react-native';
 import Constants from 'expo-constants';
 import { useRouter } from 'expo-router';
 import { useSelector } from 'react-redux';
@@ -147,6 +147,18 @@ export default function Settings() {
                         label={t('settings.rows.appearance')}
                         leftIcon={<Palette size={iconSize.secondary} color={colors.secondary} />}
                         onPress={() => router.push('/settings/appearanceView')}
+                    />
+                    <SettingsDivider />
+                    <SettingsRow
+                        label={t('settings.lyrics.title')}
+                        leftIcon={<Mic2 size={iconSize.secondary} color={colors.secondary} />}
+                        onPress={() => router.push('/settings/lyricsView')}
+                    />
+                    <SettingsDivider />
+                    <SettingsRow
+                        label={t('settings.scrobbling.title')}
+                        leftIcon={<Disc3 size={iconSize.secondary} color={colors.secondary} />}
+                        onPress={() => router.push('/settings/scrobblingView')}
                     />
                 </SettingsCard>
 

--- a/src/screens/settings/home/index.tsx
+++ b/src/screens/settings/home/index.tsx
@@ -8,7 +8,7 @@ import {
     Linking,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Server, Library, Volume2, Palette, Puzzle, CloudDownload, Github, ShieldCheck, ScrollText, House as HomeIcon, Mic2, Disc3 } from 'lucide-react-native';
+import { Server, Library, Volume2, Palette, Puzzle, CloudDownload, Github, ShieldCheck, ScrollText, House as HomeIcon, Mic2, Disc3, Sparkles, Search as SearchIcon } from 'lucide-react-native';
 import Constants from 'expo-constants';
 import { useRouter } from 'expo-router';
 import { useSelector } from 'react-redux';
@@ -153,6 +153,19 @@ export default function Settings() {
                         label={t('settings.lyrics.title')}
                         leftIcon={<Mic2 size={iconSize.secondary} color={colors.secondary} />}
                         onPress={() => router.push('/settings/lyricsView')}
+                    />
+                    <SettingsDivider />
+                    <SettingsRow
+                        label={t('settings.metadata.title')}
+                        leftIcon={<Sparkles size={iconSize.secondary} color={colors.secondary} />}
+                        onPress={() => router.push('/settings/metadataView')}
+                    />
+                    <SettingsDivider />
+                    <SettingsRow
+                        testID="settings-row-search"
+                        label={t('settings.search.title')}
+                        leftIcon={<SearchIcon size={iconSize.secondary} color={colors.secondary} />}
+                        onPress={() => router.push('/settings/searchView')}
                     />
                     <SettingsDivider />
                     <SettingsRow

--- a/src/screens/settings/integrations/listenbrainz/index.tsx
+++ b/src/screens/settings/integrations/listenbrainz/index.tsx
@@ -12,7 +12,6 @@ import {
   selectListenBrainzToken,
   selectListenBrainzAuthenticated,
   selectListenBrainzConfig,
-  selectListenBrainzScrobbleEnabled,
 } from '@/utils/redux/selectors/listenbrainzSelectors';
 import { selectListenbrainzDiscoveryEnabled } from '@/utils/redux/selectors/settingsSelectors';
 import { setListenbrainzDiscoveryEnabled } from '@/utils/redux/slices/settingsSlice';
@@ -21,7 +20,6 @@ import {
   setToken,
   setAuthenticated,
   disconnect,
-  setScrobbleEnabled,
 } from '@/utils/redux/slices/listenbrainzSlice';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import * as listenbrainz from '@/api/listenbrainz';
@@ -36,10 +34,8 @@ const ListenBrainzView: React.FC = () => {
   const token = useSelector(selectListenBrainzToken);
   const isAuthenticated = useSelector(selectListenBrainzAuthenticated);
   const config = useSelector(selectListenBrainzConfig);
-  const scrobbleEnabled = useSelector(selectListenBrainzScrobbleEnabled);
   const discoveryEnabled = useSelector(selectListenbrainzDiscoveryEnabled);
 
-  const toggleScrobble = useCallback((v: boolean) => { dispatch(setScrobbleEnabled({ serverId, value: v })); }, [dispatch, serverId]);
   const toggleDiscovery = useCallback((v: boolean) => { dispatch(setListenbrainzDiscoveryEnabled(v)); }, [dispatch]);
 
   // Discovery reads the public similar-artist graph, which takes no account —
@@ -49,11 +45,6 @@ const ListenBrainzView: React.FC = () => {
   const discoveryItems = useMemo(() => [
     { label: t('settings.listenBrainz.discovery'), subtext: t('settings.listenBrainz.discoveryDescription'), value: discoveryEnabled, onValueChange: toggleDiscovery },
   ], [t, discoveryEnabled, toggleDiscovery]);
-
-  // Now-playing follows scrobble; see the note in settingsSelectors.
-  const scrobbleItems = useMemo(() => [
-    { label: t('settings.scrobbling.scrobble'), subtext: t('settings.scrobbling.scrobbleDescription'), value: scrobbleEnabled, onValueChange: toggleScrobble },
-  ], [t, scrobbleEnabled, toggleScrobble]);
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -134,16 +125,10 @@ const ListenBrainzView: React.FC = () => {
       />
 
       {isAuthenticated && (
-        <>
-          <SettingsToggleGroup
-            items={scrobbleItems}
-          />
-
-          <SettingsDisconnectButton
-            label={t('settings.listenBrainz.disconnect')}
-            onPress={handleDisconnect}
-          />
-        </>
+        <SettingsDisconnectButton
+          label={t('settings.listenBrainz.disconnect')}
+          onPress={handleDisconnect}
+        />
       )}
     </SettingsScreen>
   );

--- a/src/screens/settings/lyrics/index.tsx
+++ b/src/screens/settings/lyrics/index.tsx
@@ -1,0 +1,100 @@
+import React, { useCallback, useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Check } from 'lucide-react-native';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import SettingsScreen from '../components/SettingsScreen';
+import SettingsCard from '../components/SettingsCard';
+import SettingsCardHeader from '../components/SettingsCardHeader';
+import SettingsDivider from '../components/SettingsDivider';
+import SettingsToggleGroup from '../components/SettingsToggleGroup';
+import { useTheme } from '@/hooks/useTheme';
+import { iconSize, spacing, typography } from '@/constants/design';
+import { selectLyricsExternalSourceEnabled } from '@/utils/redux/selectors/settingsSelectors';
+import { setLyricsExternalSourceEnabled } from '@/utils/redux/slices/settingsSlice';
+
+/**
+ * Lyrics fallback chain.
+ *
+ * Server-embedded lyrics are drawn as a fixed, non-toggleable first entry —
+ * they are what `resolveLyrics` always tries first, and there is no reason
+ * to let a user turn off a lookup that costs nothing and asks no external
+ * service. Below it: every external source the app knows, off by default,
+ * with only LRCLIB available at launch. A single source needs no drag
+ * handle to "reorder"; the moment a second source ships, this list grows an
+ * actual reorder control rather than the order silently mattering with no
+ * way to see or change it.
+ */
+const LyricsSettings: React.FC = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { colors } = useTheme();
+
+  const lrclibEnabled = useSelector(selectLyricsExternalSourceEnabled('lrclib'));
+
+  const toggleLrclib = useCallback(
+    (enabled: boolean) => {
+      dispatch(setLyricsExternalSourceEnabled({ sourceId: 'lrclib', enabled }));
+    },
+    [dispatch]
+  );
+
+  const externalSourceItems = useMemo(
+    () => [
+      {
+        label: t('settings.lyrics.lrclib'),
+        subtext: t('settings.lyrics.lrclibSubtext'),
+        value: lrclibEnabled,
+        onValueChange: toggleLrclib,
+      },
+    ],
+    [t, lrclibEnabled, toggleLrclib]
+  );
+
+  return (
+    <SettingsScreen title={t('settings.lyrics.title')}>
+      <SettingsCardHeader subtle title={t('settings.lyrics.order')} />
+      <SettingsCard>
+        <View style={styles.pinnedRow} testID="lyrics-server-embedded-row">
+          <View style={styles.pinnedLeft}>
+            <Check size={iconSize.secondary} color={colors.themeColor} />
+            <View style={styles.pinnedText}>
+              <Text style={[styles.pinnedLabel, { color: colors.secondary }]}>
+                {t('settings.lyrics.serverEmbedded')}
+              </Text>
+              <Text style={[styles.pinnedSubtext, { color: colors.subtext }]}>
+                {t('settings.lyrics.serverEmbeddedSubtext')}
+              </Text>
+            </View>
+          </View>
+        </View>
+        <SettingsDivider />
+        <SettingsToggleGroup items={externalSourceItems} />
+      </SettingsCard>
+    </SettingsScreen>
+  );
+};
+
+export default LyricsSettings;
+
+const styles = StyleSheet.create({
+  pinnedRow: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  pinnedLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  pinnedText: {
+    marginLeft: spacing.md,
+    flexShrink: 1,
+  },
+  pinnedLabel: {
+    ...typography.rowTitle,
+  },
+  pinnedSubtext: {
+    ...typography.caption,
+    marginTop: spacing.xxs,
+  },
+});

--- a/src/screens/settings/metadata/index.tsx
+++ b/src/screens/settings/metadata/index.tsx
@@ -1,0 +1,109 @@
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import SettingsScreen from '../components/SettingsScreen';
+import SettingsCard from '../components/SettingsCard';
+import SettingsCardHeader from '../components/SettingsCardHeader';
+import SettingsToggleGroup from '../components/SettingsToggleGroup';
+import {
+  selectMetadataArtistInfoSourceEnabled,
+  selectMetadataArtworkSourceEnabled,
+} from '@/utils/redux/selectors/settingsSelectors';
+import {
+  setMetadataArtistInfoSourceEnabled,
+  setMetadataArtworkSourceEnabled,
+} from '@/utils/redux/slices/settingsSlice';
+
+/**
+ * Metadata enrichment settings (`metadata.enrich`, see D3): two entirely
+ * independent fallback chains — artist information and artwork — each with
+ * its own ordered set of enabled sources.
+ *
+ * Both ship off. Enrichment here is DISPLAY-ONLY and GAPS-ONLY: it never
+ * writes anything back to a server, and a source only ever gets a chance to
+ * fill in a bio/tag/image when the server itself has none. Turning a source
+ * off (or the last source in a chain off) simply removes it from the try
+ * order, which means the resolver has nothing to try and the UI falls back
+ * to exactly the server's own view — the same restoration LyricsSettings
+ * relies on for its own fallback chain.
+ *
+ * A single source per chain at launch needs no drag handle to reorder; the
+ * moment a second source ships in either chain, this screen grows an actual
+ * reorder control rather than the order silently mattering with no way to
+ * see or change it (matching the precedent set by LyricsSettings).
+ */
+const MetadataSettings: React.FC = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  const lastfmEnabled = useSelector(selectMetadataArtistInfoSourceEnabled('lastfm'));
+  const deezerArtworkEnabled = useSelector(selectMetadataArtworkSourceEnabled('deezer'));
+  const coverArtArchiveEnabled = useSelector(selectMetadataArtworkSourceEnabled('coverartarchive'));
+
+  const toggleLastfm = useCallback(
+    (enabled: boolean) => {
+      dispatch(setMetadataArtistInfoSourceEnabled({ sourceId: 'lastfm', enabled }));
+    },
+    [dispatch]
+  );
+  const toggleDeezerArtwork = useCallback(
+    (enabled: boolean) => {
+      dispatch(setMetadataArtworkSourceEnabled({ sourceId: 'deezer', enabled }));
+    },
+    [dispatch]
+  );
+  const toggleCoverArtArchive = useCallback(
+    (enabled: boolean) => {
+      dispatch(setMetadataArtworkSourceEnabled({ sourceId: 'coverartarchive', enabled }));
+    },
+    [dispatch]
+  );
+
+  const artistInfoItems = useMemo(
+    () => [
+      {
+        label: t('settings.metadata.lastfm'),
+        subtext: t('settings.metadata.lastfmSubtext'),
+        value: lastfmEnabled,
+        onValueChange: toggleLastfm,
+      },
+    ],
+    [t, lastfmEnabled, toggleLastfm]
+  );
+
+  const artworkItems = useMemo(
+    () => [
+      {
+        label: t('settings.metadata.deezerArtwork'),
+        subtext: t('settings.metadata.deezerArtworkSubtext'),
+        value: deezerArtworkEnabled,
+        onValueChange: toggleDeezerArtwork,
+      },
+      {
+        label: t('settings.metadata.coverArtArchive'),
+        subtext: t('settings.metadata.coverArtArchiveSubtext'),
+        value: coverArtArchiveEnabled,
+        onValueChange: toggleCoverArtArchive,
+      },
+    ],
+    [t, deezerArtworkEnabled, toggleDeezerArtwork, coverArtArchiveEnabled, toggleCoverArtArchive]
+  );
+
+  return (
+    <SettingsScreen title={t('settings.metadata.title')}>
+      <SettingsCardHeader subtle title={t('settings.metadata.explanation')} />
+
+      <SettingsCardHeader subtle title={t('settings.metadata.artistInfoSection')} />
+      <SettingsCard>
+        <SettingsToggleGroup items={artistInfoItems} />
+      </SettingsCard>
+
+      <SettingsCardHeader subtle title={t('settings.metadata.artworkSection')} />
+      <SettingsCard>
+        <SettingsToggleGroup items={artworkItems} />
+      </SettingsCard>
+    </SettingsScreen>
+  );
+};
+
+export default MetadataSettings;

--- a/src/screens/settings/scrobbling/index.test.tsx
+++ b/src/screens/settings/scrobbling/index.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import ScrobblingSettings from './index';
+
+const mockDispatch = jest.fn();
+let mockLastfmRoute: string = 'through-server';
+let mockListenBrainzRoute: string = 'through-server';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+}));
+
+// Pulls in react-native-reanimated transitively via SpinningLoaderCircle,
+// which doesn't transform in this jest environment — same reason
+// api/listenbrainz is mocked in scrobbleRouting.test.tsx. Not under test
+// here; SettingsSelectCard's own loading branch isn't exercised by this
+// screen (it's never given `isLoading`).
+jest.mock('@/components/SpinningLoaderCircle', () => 'SpinningLoaderCircle');
+
+jest.mock('@/api', () => ({
+  useApi: () => ({ songs: { scrobbleKind: 'scrobble' } }),
+}));
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: string) => {
+    switch (selector) {
+      case 'activeServer':
+        return { id: 'srv-1', type: 'navidrome' };
+      case 'lastfmRoute':
+        return mockLastfmRoute;
+      case 'listenBrainzRoute':
+        return mockListenBrainzRoute;
+      default:
+        return undefined;
+    }
+  },
+}));
+
+jest.mock('@/utils/redux/selectors/serversSelectors', () => ({
+  selectActiveServer: 'activeServer',
+}));
+
+jest.mock('@/utils/redux/selectors/scrobbleRoutingSelectors', () => ({
+  selectLastfmScrobbleRoute: 'lastfmRoute',
+  selectListenBrainzScrobbleRoute: 'listenBrainzRoute',
+}));
+
+jest.mock('@/utils/redux/slices/settingsSlice', () => ({
+  setScrobbleRoute: (payload: unknown) => ({ type: 'settings/setScrobbleRoute', payload }),
+}));
+
+describe('ScrobblingSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLastfmRoute = 'through-server';
+    mockListenBrainzRoute = 'through-server';
+  });
+
+  it('offers only Disabled/Through-server for Last.fm — no Direct option this cut', async () => {
+    const view = await render(<ScrobblingSettings />);
+    // Two Last.fm rows (disabled, through-server) plus three for ListenBrainz
+    // (disabled, through-server, direct) — five selectable route rows total.
+    expect(view.getByText('settings.scrobbling.routeDirect')).toBeTruthy();
+    // Only one "routeDisabled" label rendered per card, so both cards' rows
+    // exist; the absence of a second Direct row for Last.fm is what this
+    // test actually pins — there is exactly one Direct row in the tree.
+    expect(view.getAllByText('settings.scrobbling.routeDirect')).toHaveLength(1);
+  });
+
+  it('dispatches a per-destination route change scoped to the active server', async () => {
+    const view = await render(<ScrobblingSettings />);
+    fireEvent.press(view.getByText('settings.scrobbling.routeDirect'));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'settings/setScrobbleRoute',
+      payload: { serverId: 'srv-1', destination: 'listenbrainz', route: 'direct' },
+    });
+  });
+
+  it('shows the duplicate-scrobble risk note when a destination routes through-server', async () => {
+    const view = await render(<ScrobblingSettings />);
+    expect(view.getByTestId('scrobbling-duplicate-risk-note')).toBeTruthy();
+    expect(view.getByText('settings.scrobbling.duplicateRiskNote')).toBeTruthy();
+  });
+
+  it('hides the risk note when nothing routes through the server', async () => {
+    mockLastfmRoute = 'disabled';
+    mockListenBrainzRoute = 'direct';
+    const view = await render(<ScrobblingSettings />);
+    expect(view.queryByTestId('scrobbling-duplicate-risk-note')).toBeNull();
+  });
+});

--- a/src/screens/settings/scrobbling/index.tsx
+++ b/src/screens/settings/scrobbling/index.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { useApi } from '@/api';
+import SettingsScreen from '../components/SettingsScreen';
+import SettingsCardHeader from '../components/SettingsCardHeader';
+import SettingsSelectCard from '../components/SettingsSelectCard';
+import { useTheme } from '@/hooks/useTheme';
+import { radius, spacing, typography } from '@/constants/design';
+import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
+import {
+  selectLastfmScrobbleRoute,
+  selectListenBrainzScrobbleRoute,
+} from '@/utils/redux/selectors/scrobbleRoutingSelectors';
+import { setScrobbleRoute, type ScrobbleRoute } from '@/utils/redux/slices/settingsSlice';
+
+/**
+ * One route per destination per server: Disabled, Through the server, or
+ * Direct from Yuzic. This consolidates what used to be two independent
+ * on/off switches — one on the Server screen (server-side forwarding) and one
+ * on the ListenBrainz screen (yuzic's own direct submission) — into a single
+ * choice per destination, so a destination can't silently end up wired to
+ * both at once.
+ *
+ * Last.fm has no Direct option this cut: a real Last.fm scrobble needs a
+ * signed session (api_sig), which isn't built. Only Disabled and
+ * Through-server are offered for it; the row is simply shorter rather than
+ * showing a disabled third option, since there's nothing "coming later" to
+ * point at yet.
+ */
+const ScrobblingSettings: React.FC = () => {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const dispatch = useDispatch();
+  const api = useApi();
+  const activeServer = useSelector(selectActiveServer);
+
+  const lastfmRoute = useSelector(selectLastfmScrobbleRoute);
+  const listenBrainzRoute = useSelector(selectListenBrainzScrobbleRoute);
+
+  const setLastfmRoute = useCallback((route: ScrobbleRoute) => {
+    if (!activeServer?.id) return;
+    dispatch(setScrobbleRoute({ serverId: activeServer.id, destination: 'lastfm', route }));
+  }, [dispatch, activeServer]);
+
+  const setListenBrainzRoute = useCallback((route: ScrobbleRoute) => {
+    if (!activeServer?.id) return;
+    dispatch(setScrobbleRoute({ serverId: activeServer.id, destination: 'listenbrainz', route }));
+  }, [dispatch, activeServer]);
+
+  // Same wording the Server screen used to carry: some adapters (Subsonic)
+  // "scrobble", others (Jellyfin/Emby) only "mark as played" — the label
+  // reflects what the through-server route actually does on this server.
+  const isScrobbleKind = api.songs.scrobbleKind === 'scrobble';
+  const throughServerLabel = t(isScrobbleKind
+    ? 'settings.scrobbling.throughServer'
+    : 'settings.scrobbling.throughServerMarkAsPlayed');
+
+  const lastfmItems = useMemo(() => [
+    { key: 'disabled', label: t('settings.scrobbling.routeDisabled') },
+    { key: 'through-server', label: throughServerLabel },
+  ], [t, throughServerLabel]);
+
+  const listenBrainzItems = useMemo(() => [
+    { key: 'disabled', label: t('settings.scrobbling.routeDisabled') },
+    { key: 'through-server', label: throughServerLabel },
+    { key: 'direct', label: t('settings.scrobbling.routeDirect') },
+  ], [t, throughServerLabel]);
+
+  if (!activeServer) return null;
+
+  const anyThroughServer = lastfmRoute === 'through-server' || listenBrainzRoute === 'through-server';
+
+  return (
+    <SettingsScreen title={t('settings.scrobbling.title')}>
+      <SettingsCardHeader subtle title="Last.fm" />
+      <SettingsSelectCard
+        items={lastfmItems}
+        isSelected={key => lastfmRoute === key}
+        onSelect={key => setLastfmRoute(key as ScrobbleRoute)}
+      />
+
+      <SettingsCardHeader subtle title={t('settings.listenBrainz.title')} />
+      <SettingsSelectCard
+        items={listenBrainzItems}
+        isSelected={key => listenBrainzRoute === key}
+        onSelect={key => setListenBrainzRoute(key as ScrobbleRoute)}
+      />
+
+      {/*
+        Yuzic has no way to confirm the media server actually forwards to the
+        third-party service once "Through the server" is chosen — that
+        forwarding is configured on the server itself (e.g. Navidrome's or
+        Jellyfin's own Last.fm plugin). If a server administrator has also
+        wired up a *direct* connection independently of this app, or if a
+        listener runs another scrobbling client against the same account, the
+        same play can be counted twice on the destination's side. This is
+        honest risk disclosure, not a bug yuzic can fix — there is nothing
+        client-side to verify against.
+      */}
+      {anyThroughServer && (
+        <View
+          testID="scrobbling-duplicate-risk-note"
+          style={[styles.riskNote, { backgroundColor: colors.muted }]}
+        >
+          <Text style={[styles.riskText, { color: colors.warningText }]}>
+            {t('settings.scrobbling.duplicateRiskNote')}
+          </Text>
+        </View>
+      )}
+    </SettingsScreen>
+  );
+};
+
+export default ScrobblingSettings;
+
+const styles = StyleSheet.create({
+  riskNote: {
+    padding: spacing.md,
+    borderRadius: radius.sm,
+    marginTop: spacing.xs,
+    marginBottom: spacing.lg,
+  },
+  riskText: {
+    ...typography.caption,
+  },
+});

--- a/src/screens/settings/search/index.test.tsx
+++ b/src/screens/settings/search/index.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import SearchSettings from './index';
+
+const mockDispatch = jest.fn();
+let mockDeezerEnabled = false;
+let mockMusicbrainzEnabled = false;
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: string) => {
+    switch (selector) {
+      case 'deezerSearchEnabled':
+        return mockDeezerEnabled;
+      case 'musicbrainzSearchEnabled':
+        return mockMusicbrainzEnabled;
+      default:
+        return undefined;
+    }
+  },
+}));
+
+jest.mock('@/utils/redux/selectors/settingsSelectors', () => ({
+  selectSearchSourceEnabled: (sourceId: string) =>
+    sourceId === 'deezer' ? 'deezerSearchEnabled' : 'musicbrainzSearchEnabled',
+}));
+
+jest.mock('@/utils/redux/slices/settingsSlice', () => ({
+  setSearchSourceEnabled: (payload: unknown) => ({ type: 'settings/setSearchSourceEnabled', payload }),
+}));
+
+describe('SearchSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDeezerEnabled = false;
+    mockMusicbrainzEnabled = false;
+  });
+
+  it('lists both sources, independent of any Home/discovery state', async () => {
+    const view = await render(<SearchSettings />);
+    expect(view.getByText('settings.search.deezer')).toBeTruthy();
+    expect(view.getByText('settings.search.musicbrainz')).toBeTruthy();
+  });
+
+  it('dispatches setSearchSourceEnabled for the toggled source only', async () => {
+    const view = await render(<SearchSettings />);
+    const deezerSwitch = view.getAllByRole('switch')[0];
+    fireEvent(deezerSwitch, 'valueChange', true);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'settings/setSearchSourceEnabled',
+      payload: { sourceId: 'deezer', enabled: true },
+    });
+  });
+
+  it('reflects each source’s current search-enabled state', async () => {
+    mockDeezerEnabled = true;
+    mockMusicbrainzEnabled = false;
+    const view = await render(<SearchSettings />);
+    const switches = view.getAllByRole('switch');
+    expect(switches[0].props.value).toBe(true);
+    expect(switches[1].props.value).toBe(false);
+  });
+});

--- a/src/screens/settings/search/index.tsx
+++ b/src/screens/settings/search/index.tsx
@@ -1,0 +1,66 @@
+import React, { useCallback, useMemo } from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import SettingsScreen from '../components/SettingsScreen';
+import SettingsCard from '../components/SettingsCard';
+import SettingsToggleGroup from '../components/SettingsToggleGroup';
+import { useTheme } from '@/hooks/useTheme';
+import { spacing, typography } from '@/constants/design';
+import { selectSearchSourceEnabled } from '@/utils/redux/selectors/settingsSelectors';
+import { setSearchSourceEnabled } from '@/utils/redux/slices/settingsSlice';
+
+/**
+ * Which sources Search's "Other sources" scope may query — entirely
+ * separate from Home's discovery toggles and from the per-integration
+ * Settings pages (Deezer/MusicBrainz there govern Home shelves and the
+ * external-browse catalog, not this). A source lighting up Home says
+ * nothing about whether Search may call it.
+ *
+ * Deezer here reads (and writes) the unified `searchSourcesEnabled` map,
+ * which falls back to the older `deezerSearchEnabled` flag only when this
+ * map has no entry of its own — see `selectSearchSourceEnabled`. Toggling it
+ * from this screen writes the new map going forward; nothing here needs to
+ * touch the old flag.
+ */
+export default function SearchSettings() {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { colors } = useTheme();
+
+  const deezerEnabled = useSelector(selectSearchSourceEnabled('deezer'));
+  const musicbrainzEnabled = useSelector(selectSearchSourceEnabled('musicbrainz'));
+
+  const toggleDeezer = useCallback(
+    (enabled: boolean) => { dispatch(setSearchSourceEnabled({ sourceId: 'deezer', enabled })); },
+    [dispatch]
+  );
+  const toggleMusicbrainz = useCallback(
+    (enabled: boolean) => { dispatch(setSearchSourceEnabled({ sourceId: 'musicbrainz', enabled })); },
+    [dispatch]
+  );
+
+  const items = useMemo(() => [
+    { label: t('settings.search.deezer'), subtext: t('settings.search.deezerSubtext'), value: deezerEnabled, onValueChange: toggleDeezer },
+    { label: t('settings.search.musicbrainz'), subtext: t('settings.search.musicbrainzSubtext'), value: musicbrainzEnabled, onValueChange: toggleMusicbrainz },
+  ], [t, deezerEnabled, musicbrainzEnabled, toggleDeezer, toggleMusicbrainz]);
+
+  return (
+    <SettingsScreen title={t('settings.search.title')}>
+      <Text style={[styles.explanation, { color: colors.subtext }]}>
+        {t('settings.search.explanation')}
+      </Text>
+      <SettingsCard>
+        <SettingsToggleGroup items={items} />
+      </SettingsCard>
+    </SettingsScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  explanation: {
+    ...typography.caption,
+    paddingHorizontal: spacing.lg,
+    marginBottom: spacing.md,
+  },
+});

--- a/src/screens/settings/server/index.tsx
+++ b/src/screens/settings/server/index.tsx
@@ -16,13 +16,11 @@ import ClientCertificateCard from './components/ClientCertificateCard';
 import { selectActiveServer } from '@/utils/redux/selectors/serversSelectors';
 import {
   selectSearchScope,
-  selectServerScrobbleEnabled,
   selectQueueSyncEnabled,
   selectServerNowPlayingShelfEnabled,
 } from '@/utils/redux/selectors/settingsSelectors';
 import {
   setSearchScope,
-  setServerScrobbleEnabled,
   setQueueSyncEnabled,
   setServerNowPlayingShelfEnabled,
   type SearchScope,
@@ -37,11 +35,9 @@ const ServerSettings: React.FC = () => {
 
   const searchScope = useSelector(selectSearchScope);
   const activeServer = useSelector(selectActiveServer);
-  const serverScrobbleEnabled = useSelector(selectServerScrobbleEnabled);
   const queueSyncEnabled = useSelector(selectQueueSyncEnabled);
   const nowPlayingShelfEnabled = useSelector(selectServerNowPlayingShelfEnabled);
 
-  const toggleScrobble = useCallback((v: boolean) => { dispatch(setServerScrobbleEnabled(v)); }, [dispatch]);
   const toggleQueueSync = useCallback((v: boolean) => { dispatch(setQueueSyncEnabled(v)); }, [dispatch]);
   const toggleNowPlayingShelf = useCallback((v: boolean) => { dispatch(setServerNowPlayingShelfEnabled(v)); }, [dispatch]);
 
@@ -75,17 +71,6 @@ const ServerSettings: React.FC = () => {
   // Now-playing follows scrobble; there was a separate row for it and the two
   // states were never independently useful — a user who doesn't want the
   // finished listen submitted doesn't want the in-progress broadcast either.
-  const scrobbleItems = useMemo(() => {
-    const isScrobble = api.songs.scrobbleKind === 'scrobble';
-    return [{
-      label: t(isScrobble ? 'settings.scrobbling.scrobble' : 'settings.scrobbling.markAsPlayed'),
-      subtext: t(isScrobble
-        ? 'settings.scrobbling.scrobbleDescription'
-        : 'settings.scrobbling.markAsPlayedDescription'),
-      value: serverScrobbleEnabled,
-      onValueChange: toggleScrobble,
-    }];
-  }, [t, api, serverScrobbleEnabled, toggleScrobble]);
   const [isLoading, setIsLoading] = useState(false);
 
   const serverUrl = activeServer?.serverUrl;
@@ -175,13 +160,6 @@ const ServerSettings: React.FC = () => {
         isSelected={key => searchScope === key}
         onSelect={key => dispatch(setSearchScope(key as SearchScope))}
       />
-
-      {activeServer && (
-        <>
-          <SettingsCardHeader subtle title={t('settings.scrobbling.title')} />
-          <SettingsToggleGroup items={scrobbleItems} />
-        </>
-      )}
 
       {privacyItems.length > 0 && (
         <>

--- a/src/utils/redux/selectors/scrobbleRoutingSelectors.test.ts
+++ b/src/utils/redux/selectors/scrobbleRoutingSelectors.test.ts
@@ -1,0 +1,115 @@
+import { configureStore, combineReducers } from '@reduxjs/toolkit'
+import settingsReducer, { setScrobbleRoute } from '@/utils/redux/slices/settingsSlice'
+import serversReducer, { addServer, setActiveServer } from '@/utils/redux/slices/serversSlice'
+import listenbrainzReducer, { setScrobbleEnabled } from '@/utils/redux/slices/listenbrainzSlice'
+import {
+  deriveScrobbleRoute,
+  selectLastfmScrobbleRoute,
+  selectListenBrainzScrobbleRoute,
+} from './scrobbleRoutingSelectors'
+import type { Server } from '@/types'
+
+function makeStore() {
+  return configureStore({
+    reducer: combineReducers({
+      settings: settingsReducer,
+      servers: serversReducer,
+      listenbrainz: listenbrainzReducer,
+    }),
+  })
+}
+
+const server: Server = {
+  id: 'srv-1',
+  type: 'navidrome',
+  serverUrl: 'https://media.example',
+  username: 'ari',
+  auth: { password: 'pw' },
+  isAuthenticated: true,
+}
+
+describe('deriveScrobbleRoute — no-migration default from today\'s booleans', () => {
+  it('lastfm: server scrobble on maps to through-server', () => {
+    expect(deriveScrobbleRoute('lastfm', true, false)).toBe('through-server')
+  })
+  it('lastfm: server scrobble off maps to disabled, never direct', () => {
+    expect(deriveScrobbleRoute('lastfm', false, true)).toBe('disabled')
+    expect(deriveScrobbleRoute('lastfm', false, false)).toBe('disabled')
+  })
+  it('listenbrainz: its own scrobble toggle on wins as direct', () => {
+    expect(deriveScrobbleRoute('listenbrainz', true, true)).toBe('direct')
+    expect(deriveScrobbleRoute('listenbrainz', false, true)).toBe('direct')
+  })
+  it('listenbrainz: server scrobble on, LB own toggle off maps to through-server', () => {
+    expect(deriveScrobbleRoute('listenbrainz', true, false)).toBe('through-server')
+  })
+  it('listenbrainz: both off maps to disabled', () => {
+    expect(deriveScrobbleRoute('listenbrainz', false, false)).toBe('disabled')
+  })
+})
+
+function stateOf(store: ReturnType<typeof makeStore>) {
+  return store.getState() as unknown as import('@/utils/redux/store').RootState
+}
+
+describe('scrobble route selectors — persistence and defaults, per server/destination', () => {
+  it('derives lastfm route from serverScrobbleEnabled default when nothing stored', () => {
+    const store = makeStore()
+    store.dispatch(addServer(server))
+    store.dispatch(setActiveServer(server.id))
+    // Default serverScrobbleEnabled is true.
+    expect(selectLastfmScrobbleRoute(stateOf(store))).toBe('through-server')
+  })
+
+  it('derives listenbrainz route from its own per-server boolean default (off) as through-server', () => {
+    const store = makeStore()
+    store.dispatch(addServer(server))
+    store.dispatch(setActiveServer(server.id))
+    expect(selectListenBrainzScrobbleRoute(stateOf(store))).toBe('through-server')
+  })
+
+  it('an explicit stored route always wins over the derived default', () => {
+    const store = makeStore()
+    store.dispatch(addServer(server))
+    store.dispatch(setActiveServer(server.id))
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'listenbrainz', route: 'direct' }))
+    expect(selectListenBrainzScrobbleRoute(stateOf(store))).toBe('direct')
+
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'lastfm', route: 'disabled' }))
+    expect(selectLastfmScrobbleRoute(stateOf(store))).toBe('disabled')
+  })
+
+  it('a route is scoped per server — a route set for one server does not leak to another', () => {
+    const store = makeStore()
+    const server2: Server = { ...server, id: 'srv-2' }
+    store.dispatch(addServer(server))
+    store.dispatch(addServer(server2))
+    store.dispatch(setActiveServer(server.id))
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'listenbrainz', route: 'direct' }))
+
+    expect(selectListenBrainzScrobbleRoute(stateOf(store))).toBe('direct')
+
+    store.dispatch(setActiveServer(server2.id))
+    // server2 has no stored route and no legacy LB boolean set — derives to
+    // through-server via the still-true serverScrobbleEnabled default.
+    expect(selectListenBrainzScrobbleRoute(stateOf(store))).toBe('through-server')
+  })
+
+  it('setting one destination does not affect the other for the same server', () => {
+    const store = makeStore()
+    store.dispatch(addServer(server))
+    store.dispatch(setActiveServer(server.id))
+    store.dispatch(setScrobbleRoute({ serverId: server.id, destination: 'listenbrainz', route: 'direct' }))
+
+    // lastfm still derives from the untouched serverScrobbleEnabled default.
+    expect(selectLastfmScrobbleRoute(stateOf(store))).toBe('through-server')
+  })
+
+  it('legacy per-server ListenBrainz scrobbleEnabled=true still derives to direct with no stored route', () => {
+    const store = makeStore()
+    store.dispatch(addServer(server))
+    store.dispatch(setActiveServer(server.id))
+    store.dispatch(setScrobbleEnabled({ serverId: server.id, value: true }))
+    expect(selectListenBrainzScrobbleRoute(stateOf(store))).toBe('direct')
+  })
+})

--- a/src/utils/redux/selectors/scrobbleRoutingSelectors.ts
+++ b/src/utils/redux/selectors/scrobbleRoutingSelectors.ts
@@ -1,0 +1,69 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { RootState } from '@/utils/redux/store';
+import type { ScrobbleDestinationKind, ScrobbleRoute } from '@/utils/redux/slices/settingsSlice';
+import { selectActiveServerId } from '@/utils/redux/selectors/serversSelectors';
+
+/**
+ * Per-destination route for the active server, derived with NO migration.
+ *
+ * A server that stored an explicit route (via `setScrobbleRoute`) always
+ * reads that back. A server that never has — every server that existed
+ * before this feature, and every new server that hasn't visited the
+ * Scrobbling screen yet — gets a route derived on the fly from today's two
+ * independent booleans:
+ *  - lastfm: `serverScrobbleEnabled` maps to 'through-server' (the server is
+ *    what would forward to Last.fm), off maps to 'disabled'. Never 'direct'
+ *    — Last.fm-direct isn't built this cut.
+ *  - listenbrainz: today's two switches were never meant to combine, but a
+ *    route can only hold one value, so 'direct' (yuzic's own LB scrobble)
+ *    wins when both happen to be on, since it strictly subsumes what
+ *    'through-server' would forward. Only `serverScrobbleEnabled` on and per-
+ *    server LB scrobble off means 'through-server'; LB on alone means
+ *    'direct'; both off means 'disabled'.
+ *
+ * Deriving at read time rather than writing a migration means an upgrading
+ * user sees the same effective behaviour as before with zero new state, and
+ * a fresh install with the defaults (`serverScrobbleEnabled: true`, LB
+ * per-server scrobble off) derives to lastfm 'through-server' / listenbrainz
+ * 'through-server' — matching the two booleans' own defaults.
+ */
+export function deriveScrobbleRoute(
+  destination: ScrobbleDestinationKind,
+  serverScrobbleEnabled: boolean,
+  lbScrobbleEnabled: boolean
+): ScrobbleRoute {
+  if (destination === 'lastfm') {
+    return serverScrobbleEnabled ? 'through-server' : 'disabled';
+  }
+  // listenbrainz
+  if (lbScrobbleEnabled) return 'direct';
+  if (serverScrobbleEnabled) return 'through-server';
+  return 'disabled';
+}
+
+const selectScrobbleRoutesForActiveServer = createSelector(
+  [(s: RootState) => s.settings.scrobbleRoutes, selectActiveServerId],
+  (scrobbleRoutes, activeServerId) =>
+    (activeServerId ? scrobbleRoutes?.[activeServerId] : undefined)
+);
+
+export const selectScrobbleRoute = (destination: ScrobbleDestinationKind) =>
+  createSelector(
+    [
+      selectScrobbleRoutesForActiveServer,
+      (s: RootState) => s.settings.serverScrobbleEnabled ?? true,
+      (s: RootState) => {
+        const activeServerId = s.servers.activeServerId;
+        const entry = activeServerId ? s.listenbrainz.byServer[activeServerId] : undefined;
+        return entry?.scrobbleEnabled ?? false;
+      },
+    ],
+    (routes, serverScrobbleEnabled, lbScrobbleEnabled): ScrobbleRoute => {
+      const stored = routes?.[destination];
+      if (stored) return stored;
+      return deriveScrobbleRoute(destination, serverScrobbleEnabled, lbScrobbleEnabled);
+    }
+  );
+
+export const selectLastfmScrobbleRoute = selectScrobbleRoute('lastfm');
+export const selectListenBrainzScrobbleRoute = selectScrobbleRoute('listenbrainz');

--- a/src/utils/redux/selectors/searchSourcesSelectors.test.ts
+++ b/src/utils/redux/selectors/searchSourcesSelectors.test.ts
@@ -1,0 +1,63 @@
+import type { RootState } from '@/utils/redux/store'
+import {
+  selectEnabledSearchSourceIds,
+  selectSearchSourceEnabled,
+} from './settingsSelectors'
+
+function stateWith(settings: Record<string, unknown>): RootState {
+  return { settings } as unknown as RootState
+}
+
+describe('selectSearchSourceEnabled', () => {
+  it('is off by default for every source — enabling nothing without being asked', () => {
+    const empty = stateWith({})
+    expect(selectSearchSourceEnabled('deezer')(empty)).toBe(false)
+    expect(selectSearchSourceEnabled('musicbrainz')(empty)).toBe(false)
+  })
+
+  it('reads the unified map once a source has an explicit entry', () => {
+    const state = stateWith({ searchSourcesEnabled: { deezer: true, musicbrainz: false } })
+    expect(selectSearchSourceEnabled('deezer')(state)).toBe(true)
+    expect(selectSearchSourceEnabled('musicbrainz')(state)).toBe(false)
+  })
+
+  it('reconciles Deezer with the older deezerSearchEnabled flag when the map has no entry — no migration needed', () => {
+    const legacy = stateWith({ deezerSearchEnabled: true })
+    expect(selectSearchSourceEnabled('deezer')(legacy)).toBe(true)
+  })
+
+  it('an explicit map entry overrides the legacy flag once the user has touched the new setting', () => {
+    const state = stateWith({ deezerSearchEnabled: true, searchSourcesEnabled: { deezer: false } })
+    expect(selectSearchSourceEnabled('deezer')(state)).toBe(false)
+  })
+
+  it('musicbrainz has no legacy flag to fall back to — just off until asked for', () => {
+    expect(selectSearchSourceEnabled('musicbrainz')(stateWith({}))).toBe(false)
+  })
+})
+
+describe('selectEnabledSearchSourceIds', () => {
+  it('is empty by default — search enablement is independent of Home and starts off', () => {
+    expect(selectEnabledSearchSourceIds(stateWith({}))).toEqual([])
+  })
+
+  it('is independent of Home/discovery enablement', () => {
+    // Every Home/discovery flag turned on, nothing in the search map.
+    const state = stateWith({
+      deezerDiscoveryEnabled: true,
+      deezerExternalEnabled: true,
+      musicbrainzExternalEnabled: true,
+    })
+    expect(selectEnabledSearchSourceIds(state)).toEqual([])
+  })
+
+  it('includes exactly the sources explicitly enabled for search', () => {
+    const state = stateWith({ searchSourcesEnabled: { deezer: true, musicbrainz: true } })
+    expect(selectEnabledSearchSourceIds(state).sort()).toEqual(['deezer', 'musicbrainz'])
+  })
+
+  it('honors the legacy deezerSearchEnabled flag with no explicit map entry', () => {
+    const state = stateWith({ deezerSearchEnabled: true })
+    expect(selectEnabledSearchSourceIds(state)).toEqual(['deezer'])
+  })
+})

--- a/src/utils/redux/selectors/settingsSelectors.ts
+++ b/src/utils/redux/selectors/settingsSelectors.ts
@@ -148,6 +148,27 @@ export const selectDeezerExternalEnabled = (state: RootState): boolean =>
 export const selectMusicbrainzExternalEnabled = (state: RootState): boolean =>
   state.settings.musicbrainzExternalEnabled ?? false;
 
+/**
+ * Whether one source is enabled for the Search screen's "Other sources"
+ * scope. `searchSourcesEnabled` is the unified map; Deezer additionally
+ * falls back to the older `deezerSearchEnabled` flag when it has no entry of
+ * its own, so a user who already turned Deezer search on before this map
+ * existed keeps seeing it on — read-time reconciliation, no migration.
+ */
+export const selectSearchSourceEnabled = (sourceId: string) =>
+  (state: RootState): boolean => {
+    const explicit = state.settings.searchSourcesEnabled?.[sourceId];
+    if (explicit !== undefined) return explicit;
+    if (sourceId === 'deezer') return state.settings.deezerSearchEnabled ?? false;
+    return false;
+  };
+
+/** Every source id enabled for Search, independent of Home/discovery. */
+export const selectEnabledSearchSourceIds = (state: RootState): string[] => {
+  const ids = new Set<string>(['deezer', 'musicbrainz']);
+  return [...ids].filter(id => selectSearchSourceEnabled(id)(state));
+};
+
 /** Off until asked for: see the note on the field in settingsSlice. */
 export const selectListenbrainzDiscoveryEnabled = (state: RootState): boolean =>
   state.settings.listenbrainzDiscoveryEnabled ?? false;
@@ -194,6 +215,34 @@ export const selectLyricsExternalSourcesOrder = (state: RootState): string[] =>
 
 export const selectLyricsExternalSourceEnabled = (sourceId: string) =>
   (state: RootState): boolean => state.settings.lyricsExternalSourcesEnabled?.[sourceId] ?? false;
+
+/**
+ * `metadata.enrich` selectors — same shape as the lyrics pair above, kept as
+ * two entirely independent chains (artist-info, artwork) per the D3 design.
+ */
+export const selectEnabledMetadataArtistInfoSourcesInOrder = (state: RootState): string[] => {
+  const order = state.settings.metadataArtistInfoOrder ?? [];
+  const enabled = state.settings.metadataArtistInfoEnabled ?? {};
+  return order.filter(sourceId => enabled[sourceId]);
+};
+
+export const selectMetadataArtistInfoOrder = (state: RootState): string[] =>
+  state.settings.metadataArtistInfoOrder ?? [];
+
+export const selectMetadataArtistInfoSourceEnabled = (sourceId: string) =>
+  (state: RootState): boolean => state.settings.metadataArtistInfoEnabled?.[sourceId] ?? false;
+
+export const selectEnabledMetadataArtworkSourcesInOrder = (state: RootState): string[] => {
+  const order = state.settings.metadataArtworkOrder ?? [];
+  const enabled = state.settings.metadataArtworkEnabled ?? {};
+  return order.filter(sourceId => enabled[sourceId]);
+};
+
+export const selectMetadataArtworkOrder = (state: RootState): string[] =>
+  state.settings.metadataArtworkOrder ?? [];
+
+export const selectMetadataArtworkSourceEnabled = (sourceId: string) =>
+  (state: RootState): boolean => state.settings.metadataArtworkEnabled?.[sourceId] ?? false;
 
 /**
  * Crossfade, as the engine wants it, or `null` when it is off.

--- a/src/utils/redux/selectors/settingsSelectors.ts
+++ b/src/utils/redux/selectors/settingsSelectors.ts
@@ -174,6 +174,28 @@ export const selectHomeServerSectionsEnabled = (state: RootState): boolean =>
   state.settings.homeServerSectionsEnabled ?? true;
 
 /**
+ * Enabled external lyric sources, in the user's try-order.
+ *
+ * Filters `lyricsExternalSourcesOrder` down to the ones actually enabled
+ * rather than trusting the order list alone, so a source that was disabled
+ * without being removed from the order (or an id from a future version this
+ * one doesn't recognise) never gets called. Empty by default — the whole
+ * point being that a fresh install/upgrade resolves lyrics server-only,
+ * with no external calls at all, until the user opts in.
+ */
+export const selectEnabledLyricsExternalSourcesInOrder = (state: RootState): string[] => {
+  const order = state.settings.lyricsExternalSourcesOrder ?? [];
+  const enabled = state.settings.lyricsExternalSourcesEnabled ?? {};
+  return order.filter(sourceId => enabled[sourceId]);
+};
+
+export const selectLyricsExternalSourcesOrder = (state: RootState): string[] =>
+  state.settings.lyricsExternalSourcesOrder ?? [];
+
+export const selectLyricsExternalSourceEnabled = (sourceId: string) =>
+  (state: RootState): boolean => state.settings.lyricsExternalSourcesEnabled?.[sourceId] ?? false;
+
+/**
  * Crossfade, as the engine wants it, or `null` when it is off.
  *
  * Zero seconds is off rather than a zero-length fade: `null` tells the engine

--- a/src/utils/redux/slices/settingsSlice.ts
+++ b/src/utils/redux/slices/settingsSlice.ts
@@ -40,6 +40,31 @@ export type ThemeMode = 'light' | 'dark' | 'system';
 export type SearchScope = 'client' | 'server';
 export type AppLanguage = string;
 
+/**
+ * The scrobble targets a server can be routed to. Last.fm-direct is
+ * deliberately not modelled here this cut — Last.fm's real API needs a
+ * signed session (api_sig), which isn't built yet, so its route only ever
+ * takes 'disabled' | 'through-server'. ListenBrainz supports all three,
+ * because `api/listenbrainz` already scrobbles it directly with a token.
+ */
+export type ScrobbleDestinationKind = 'lastfm' | 'listenbrainz';
+export type ScrobbleRoute = 'disabled' | 'through-server' | 'direct';
+
+/**
+ * One route per destination per server — never both 'through-server' and
+ * 'direct' for the same destination, because there is only one field to hold
+ * either value. That is what keeps "exactly one route per destination" true
+ * by construction rather than by convention.
+ *
+ * Missing entries (a server that predates this feature) fall back to a
+ * default derived from the old `serverScrobbleEnabled` /
+ * ListenBrainz-per-server `scrobbleEnabled` booleans — see
+ * `selectors/scrobbleRoutingSelectors.ts`. There is deliberately no migration
+ * that writes this field on load; a stored route always wins once one exists,
+ * and everyone else keeps reading the derived default forever.
+ */
+export type ScrobbleRoutes = Partial<Record<ScrobbleDestinationKind, ScrobbleRoute>>;
+
 export interface SettingsState {
   /* UI */
   themeMode: ThemeMode;
@@ -110,6 +135,15 @@ export interface SettingsState {
    * the finished listen was never a real user intent. */
   serverScrobbleEnabled: boolean;
 
+  /**
+   * Per-server, per-destination scrobble route — see {@link ScrobbleRoutes}.
+   * Keyed by server id, same pattern as `libraryViewModes`. Absent for every
+   * server that existed before this field: `scrobbleRoutingSelectors` derives
+   * a route from `serverScrobbleEnabled` and ListenBrainz's own
+   * `scrobbleEnabled` in that case, so there is nothing to migrate here.
+   */
+  scrobbleRoutes: Record<string, ScrobbleRoutes>;
+
   /* Integrations. Deezer has three distinct dimensions (Home shelves,
    * search results, external browse); everything else that used to be a
    * sub-toggle (top tracks, similar artists, album recs, samples, playlist
@@ -140,6 +174,20 @@ export interface SettingsState {
    * (deezerDiscoveryEnabled, listenbrainzDiscoveryEnabled) rather than by a
    * second switch that could sit on while the first one is off. */
   homeServerSectionsEnabled: boolean;
+
+  /**
+   * Lyrics fallback chain, external sources only — server-embedded lyrics
+   * are always tried first and are never part of this list (see
+   * `features/lyrics/resolveLyrics`).
+   *
+   * `lyricsExternalSourcesOrder` names every external source the user has
+   * touched, in their preferred try-order; `lyricsExternalSourcesEnabled`
+   * says which of those are actually on. Both default empty/off — LRCLIB,
+   * like every external source, is off until asked for, so a fresh install
+   * behaves exactly like before this feature existed (server-only).
+   */
+  lyricsExternalSourcesOrder: string[];
+  lyricsExternalSourcesEnabled: Record<string, boolean>;
 
   /* Player controls */
   showSleepTimer: boolean;
@@ -209,6 +257,7 @@ const initialState: SettingsState = {
   language: DEFAULT_LANGUAGE,
 
   serverScrobbleEnabled: true,
+  scrobbleRoutes: {},
 
   deezerDiscoveryEnabled: false,
   deezerSearchEnabled: false,
@@ -225,6 +274,9 @@ const initialState: SettingsState = {
   resumeLongTracksEnabled: true,
 
   homeServerSectionsEnabled: true,
+
+  lyricsExternalSourcesOrder: [],
+  lyricsExternalSourcesEnabled: {},
 
   showSleepTimer: true,
   showPlaybackSpeed: false,
@@ -333,6 +385,24 @@ const settingsSlice = createSlice({
       state.serverScrobbleEnabled = action.payload;
     },
 
+    /**
+     * Sets exactly one destination's route for one server. A single field per
+     * destination is what makes "at most one route" structural rather than
+     * something call sites have to remember to enforce — setting 'direct'
+     * here already means it isn't 'through-server' any more.
+     */
+    setScrobbleRoute(
+      state,
+      action: PayloadAction<{ serverId: string; destination: ScrobbleDestinationKind; route: ScrobbleRoute }>
+    ) {
+      const { serverId, destination, route } = action.payload;
+      if (!state.scrobbleRoutes) state.scrobbleRoutes = {};
+      state.scrobbleRoutes[serverId] = {
+        ...state.scrobbleRoutes[serverId],
+        [destination]: route,
+      };
+    },
+
     setDeezerDiscoveryEnabled(state, action: PayloadAction<boolean>) {
       state.deezerDiscoveryEnabled = action.payload;
     },
@@ -363,6 +433,26 @@ const settingsSlice = createSlice({
     },
     setHomeServerSectionsEnabled(state, action: PayloadAction<boolean>) {
       state.homeServerSectionsEnabled = action.payload;
+    },
+
+    setLyricsExternalSourceEnabled(
+      state,
+      action: PayloadAction<{ sourceId: string; enabled: boolean }>
+    ) {
+      const { sourceId, enabled } = action.payload;
+      if (!state.lyricsExternalSourcesEnabled) state.lyricsExternalSourcesEnabled = {};
+      state.lyricsExternalSourcesEnabled[sourceId] = enabled;
+      // A source enabled for the first time joins the order at the end; one
+      // already present keeps its existing position rather than jumping to
+      // the back every time it's re-enabled.
+      if (!state.lyricsExternalSourcesOrder) state.lyricsExternalSourcesOrder = [];
+      if (enabled && !state.lyricsExternalSourcesOrder.includes(sourceId)) {
+        state.lyricsExternalSourcesOrder.push(sourceId);
+      }
+    },
+    /** Replaces the whole try-order (drag-to-reorder writes the full array). */
+    setLyricsExternalSourcesOrder(state, action: PayloadAction<string[]>) {
+      state.lyricsExternalSourcesOrder = action.payload;
     },
 
     setShowSleepTimer(state, action: PayloadAction<boolean>) {
@@ -443,6 +533,7 @@ export const {
   setPreferredCodec,
   setLanguage,
   setServerScrobbleEnabled,
+  setScrobbleRoute,
   setDeezerDiscoveryEnabled,
   setDeezerSearchEnabled,
   setDeezerExternalEnabled,
@@ -453,6 +544,8 @@ export const {
   setServerNowPlayingShelfEnabled,
   setResumeLongTracksEnabled,
   setHomeServerSectionsEnabled,
+  setLyricsExternalSourceEnabled,
+  setLyricsExternalSourcesOrder,
   setShowSleepTimer,
   setShowJumpButtons,
   setShowVolumeSlider,

--- a/src/utils/redux/slices/settingsSlice.ts
+++ b/src/utils/redux/slices/settingsSlice.ts
@@ -154,6 +154,17 @@ export interface SettingsState {
   deezerExternalEnabled: boolean;
   musicbrainzExternalEnabled: boolean;
   /**
+   * Which sources the user has opted into for the Search screen's "Other
+   * sources" scope — independent of Home/discovery enablement and of the
+   * per-source Settings pages above. Keyed by source id (`deezer`,
+   * `musicbrainz`). Absent keys read as off; `deezerSearchEnabled` (the
+   * older, search-specific Deezer flag) is reconciled at *read* time in
+   * `selectSearchSourceEnabled` rather than migrated here, so an existing
+   * user who already turned Deezer search on keeps seeing it on with no
+   * migration code and no double state to keep in sync.
+   */
+  searchSourcesEnabled: Record<string, boolean>;
+  /**
    * ListenBrainz's public similar-artist graph (Home shelf, artist page).
    * Needs no account, but it is still a third-party service being told which
    * artists this user listens to, so it waits to be asked for like every
@@ -188,6 +199,20 @@ export interface SettingsState {
    */
   lyricsExternalSourcesOrder: string[];
   lyricsExternalSourcesEnabled: Record<string, boolean>;
+
+  /**
+   * `metadata.enrich` — display-only artist-info / artwork gap-filling
+   * (see `features/metadata`). Two entirely independent fallback chains,
+   * mirroring the lyrics pair above: a user can enable artist-info without
+   * artwork or vice versa. Both default empty/off, so a fresh install shows
+   * exactly the server's own data until the user opts in, and disabling
+   * either chain (clearing its enabled map) restores that server-only view
+   * with no code path change — the resolvers simply have nothing to try.
+   */
+  metadataArtistInfoOrder: string[];
+  metadataArtistInfoEnabled: Record<string, boolean>;
+  metadataArtworkOrder: string[];
+  metadataArtworkEnabled: Record<string, boolean>;
 
   /* Player controls */
   showSleepTimer: boolean;
@@ -263,6 +288,7 @@ const initialState: SettingsState = {
   deezerSearchEnabled: false,
   deezerExternalEnabled: false,
   musicbrainzExternalEnabled: false,
+  searchSourcesEnabled: {},
   listenbrainzDiscoveryEnabled: false,
   lastfmEnabled: false,
 
@@ -277,6 +303,11 @@ const initialState: SettingsState = {
 
   lyricsExternalSourcesOrder: [],
   lyricsExternalSourcesEnabled: {},
+
+  metadataArtistInfoOrder: [],
+  metadataArtistInfoEnabled: {},
+  metadataArtworkOrder: [],
+  metadataArtworkEnabled: {},
 
   showSleepTimer: true,
   showPlaybackSpeed: false,
@@ -415,6 +446,14 @@ const settingsSlice = createSlice({
     setMusicbrainzExternalEnabled(state, action: PayloadAction<boolean>) {
       state.musicbrainzExternalEnabled = action.payload;
     },
+    /** Toggles one source's inclusion in Search's "Other sources" scope. */
+    setSearchSourceEnabled(
+      state,
+      action: PayloadAction<{ sourceId: string; enabled: boolean }>
+    ) {
+      if (!state.searchSourcesEnabled) state.searchSourcesEnabled = {};
+      state.searchSourcesEnabled[action.payload.sourceId] = action.payload.enabled;
+    },
     setListenbrainzDiscoveryEnabled(state, action: PayloadAction<boolean>) {
       state.listenbrainzDiscoveryEnabled = action.payload;
     },
@@ -453,6 +492,38 @@ const settingsSlice = createSlice({
     /** Replaces the whole try-order (drag-to-reorder writes the full array). */
     setLyricsExternalSourcesOrder(state, action: PayloadAction<string[]>) {
       state.lyricsExternalSourcesOrder = action.payload;
+    },
+
+    setMetadataArtistInfoSourceEnabled(
+      state,
+      action: PayloadAction<{ sourceId: string; enabled: boolean }>
+    ) {
+      const { sourceId, enabled } = action.payload;
+      if (!state.metadataArtistInfoEnabled) state.metadataArtistInfoEnabled = {};
+      state.metadataArtistInfoEnabled[sourceId] = enabled;
+      if (!state.metadataArtistInfoOrder) state.metadataArtistInfoOrder = [];
+      if (enabled && !state.metadataArtistInfoOrder.includes(sourceId)) {
+        state.metadataArtistInfoOrder.push(sourceId);
+      }
+    },
+    setMetadataArtistInfoOrder(state, action: PayloadAction<string[]>) {
+      state.metadataArtistInfoOrder = action.payload;
+    },
+
+    setMetadataArtworkSourceEnabled(
+      state,
+      action: PayloadAction<{ sourceId: string; enabled: boolean }>
+    ) {
+      const { sourceId, enabled } = action.payload;
+      if (!state.metadataArtworkEnabled) state.metadataArtworkEnabled = {};
+      state.metadataArtworkEnabled[sourceId] = enabled;
+      if (!state.metadataArtworkOrder) state.metadataArtworkOrder = [];
+      if (enabled && !state.metadataArtworkOrder.includes(sourceId)) {
+        state.metadataArtworkOrder.push(sourceId);
+      }
+    },
+    setMetadataArtworkOrder(state, action: PayloadAction<string[]>) {
+      state.metadataArtworkOrder = action.payload;
     },
 
     setShowSleepTimer(state, action: PayloadAction<boolean>) {
@@ -538,6 +609,7 @@ export const {
   setDeezerSearchEnabled,
   setDeezerExternalEnabled,
   setMusicbrainzExternalEnabled,
+  setSearchSourceEnabled,
   setListenbrainzDiscoveryEnabled,
   setLastfmEnabled,
   setQueueSyncEnabled,
@@ -546,6 +618,10 @@ export const {
   setHomeServerSectionsEnabled,
   setLyricsExternalSourceEnabled,
   setLyricsExternalSourcesOrder,
+  setMetadataArtistInfoSourceEnabled,
+  setMetadataArtistInfoOrder,
+  setMetadataArtworkSourceEnabled,
+  setMetadataArtworkOrder,
   setShowSleepTimer,
   setShowJumpButtons,
   setShowVolumeSlider,


### PR DESCRIPTION
## Phase D — Feature-oriented settings (Scrobbling / Lyrics / Metadata / Search)

Fourth of five phases. **Stacked on Phase C (#233)** — base is `feat/li-c-wants-get`. Review/merge A (#231), B (#232), C (#233) first.

Four feature pages, each organized by what the user wants yuzic to *do*, following the `screens/settings/home/` precedent. Built with parallel Sonnet subagents (D1+D2, then D3+D4); shared-file edits verified merged clean.

### What changed
- **Scrobbling** — one route *per destination, per server* (`disabled|through-server|direct`) in `settingsSlice.scrobbleRoutes`; the single enum makes "no double-scrobble" structural. Defaults derived at read time from today's booleans (**no migration**). **Last.fm: disabled/through-server only** (direct sequenced out). Toggles relocated off the server + ListenBrainz screens; duplicate-risk note on through-server.
- **Lyrics** — new `api/lrclib` (none-tier, no key, LRC parser, synced-preferred *one source*) + `features/lyrics/resolveLyrics` (server-embedded first, then user-ordered externals), wired into the playing screen. Off by default → server-only behaviour unchanged.
- **Metadata** — Last.fm `artist.getInfo` + Deezer/Cover Art Archive; two independent ordered chains (`resolveArtistInfo`/`resolveArtwork`). **Display-only + gaps-only**: never writes server tags, only fills empty fields, disabling restores the server view; "via X" line, no per-item badges; off by default. Wired into artist BioSection (album-cover artwork = documented follow-up).
- **Search** — segmented **Your Library** (default, no external calls) / **Other sources** scope + Filters sheet; `searchSourcesEnabled` independent of Home (legacy `deezerSearchEnabled` reconciled at read time, no migration). `planSearchLegs` picks library **XOR** external — no default mixing; provenance preserved, editions/ambiguous separate.
- `docs/architecture.md` §9.

### Deliberately NOT done
- No Last.fm signed-session scrobbling (sequenced). No migration code (per steer). Broad album-cover artwork rewrite deferred (documented).

### Verification
- `npx tsc --noEmit` — exit 0
- `npx jest --ci` — **1205 passed** (+83 over Phase C's 1122)
- `npm run lint` — 0 errors / 51 warnings (≤ 52 baseline; one pre-existing warning incidentally cleared)

3 commits (D1+D2 pages, D3+D4 pages, D5 docs+sweep). Each subagent verified from clean before commit; combined tree re-verified after each parallel pair.

🤖 Generated with [Claude Code](https://claude-code.nousresearch.com)
