### PR TITLE
fix: standardize full-screen empty states

### DIFF
--- a/src/components/EmptyState.test.tsx
+++ b/src/components/EmptyState.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+import EmptyState from './EmptyState';
+
+let mockBottomOverlayHeight = 0;
+
+jest.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({ colors: { subtext: '#666', border: '#333', text: '#fff' } }),
+}));
+
+jest.mock('@/hooks/useScrollClearance', () => ({
+  useBottomOverlayHeight: () => mockBottomOverlayHeight,
+}));
+
+describe('EmptyState', () => {
+  it('removes an overlaying dock and playing bar from the centering area', async () => {
+    mockBottomOverlayHeight = 144;
+    const view = await render(<EmptyState message="Nothing here" />);
+
+    expect(StyleSheet.flatten(view.getByTestId('empty-state').props.style)).toMatchObject({
+      flex: 1,
+      justifyContent: 'center',
+      paddingBottom: 144,
+    });
+  });
+
+  it('adds no offset when the dock already participates in layout', async () => {
+    mockBottomOverlayHeight = 0;
+    const view = await render(<EmptyState message="Nothing here" />);
+
+    expect(StyleSheet.flatten(view.getByTestId('empty-state').props.style).paddingBottom).toBe(0);
+  });
+});

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 import { spacing, typography, radius } from '@/constants/design';
+import { useBottomOverlayHeight } from '@/hooks/useScrollClearance';
 import Touchable from './Touchable';
 
 type Props = {
@@ -25,9 +26,10 @@ type Props = {
  */
 const EmptyState: React.FC<Props> = ({ icon, message, action }) => {
   const { colors } = useTheme();
+  const bottomOverlayHeight = useBottomOverlayHeight();
 
   return (
-    <View style={styles.container}>
+    <View testID="empty-state" style={[styles.container, { paddingBottom: bottomOverlayHeight }]}>
       {icon}
       <Text style={[styles.message, { color: colors.subtext }]}>{message}</Text>
       {action ? (

--- a/src/hooks/useScrollClearance.test.ts
+++ b/src/hooks/useScrollClearance.test.ts
@@ -1,0 +1,15 @@
+import { resolveBottomOverlayHeight } from './useScrollClearance';
+
+describe('resolveBottomOverlayHeight', () => {
+  it('returns the full dock height when a translucent dock overlays the screen', () => {
+    expect(resolveBottomOverlayHeight(true, 144)).toBe(144);
+  });
+
+  it('returns zero when the dock participates in layout', () => {
+    expect(resolveBottomOverlayHeight(false, 144)).toBe(0);
+  });
+
+  it('returns zero outside the tab navigator', () => {
+    expect(resolveBottomOverlayHeight(true, null)).toBe(0);
+  });
+});

--- a/src/hooks/useScrollClearance.ts
+++ b/src/hooks/useScrollClearance.ts
@@ -20,12 +20,23 @@ import { selectTranslucentDock } from '@/utils/redux/selectors/settingsSelectors
  * step: the dock's height changes with the safe-area inset and with whether a
  * track is playing, and a hardcoded guess would be wrong on both counts.
  */
-export function useScrollClearance(): number {
+export function resolveBottomOverlayHeight(
+  translucent: boolean,
+  tabBarHeight: number | null | undefined
+): number {
+  if (!translucent || tabBarHeight == null) return 0;
+  return tabBarHeight;
+}
+
+export function useBottomOverlayHeight(): number {
   const translucent = useSelector(selectTranslucentDock);
   // Null outside a tab navigator — modals and the onboarding stack render
-  // without a dock, and want the plain value.
+  // without a dock, so nothing overlays their content.
   const tabBarHeight = useContext(BottomTabBarHeightContext);
 
-  if (!translucent || tabBarHeight == null) return spacing.scrollClearance;
-  return tabBarHeight + spacing.scrollClearance;
+  return resolveBottomOverlayHeight(translucent, tabBarHeight);
+}
+
+export function useScrollClearance(): number {
+  return useBottomOverlayHeight() + spacing.scrollClearance;
 }

--- a/src/screens/genres/index.tsx
+++ b/src/screens/genres/index.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux'
 import { ChevronRight } from 'lucide-react-native'
 
 import { DetailHeaderBar } from '@/components/DetailHeader'
+import EmptyState from '@/components/EmptyState'
 import { useTheme } from '@/hooks/useTheme'
 import { iconSize, spacing, typography } from '@/constants/design'
 import { useAlbums } from '@/hooks/albums'
@@ -66,9 +67,7 @@ const GenresScreen: React.FC = () => {
         // exactly like a library with no genres.
         <LoadingGenreList />
       ) : rows.length === 0 ? (
-        <Text style={[styles.empty, { color: colors.subtext }]}>
-          {t('library.genres.empty')}
-        </Text>
+        <EmptyState message={t('library.genres.empty')} />
       ) : (
         <FlashList<GenreRow>
           data={rows}
@@ -97,5 +96,4 @@ const styles = StyleSheet.create({
   rowText: { flex: 1, minWidth: 0, marginRight: spacing.rowGap },
   genre: { ...typography.rowTitle },
   count: { ...typography.caption, marginTop: spacing.xxs },
-  empty: { ...typography.rowSubtitle, textAlign: 'center', marginTop: spacing.xxl },
 })

--- a/src/screens/home/LocalMixScreen.tsx
+++ b/src/screens/home/LocalMixScreen.tsx
@@ -1,16 +1,17 @@
 import React, { useCallback } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { notify } from '@/components/toast';
 
 import { DetailHeaderBar } from '@/components/DetailHeader';
+import EmptyState from '@/components/EmptyState';
 import SongRow from '@/components/rows/SongRow';
 import LoadingSongRow from '@/components/rows/SongRow/Loading';
 import { usePlayingActions } from '@/contexts/PlayingContext';
 import { useTheme } from '@/hooks/useTheme';
-import { spacing, typography } from '@/constants/design';
+import { spacing } from '@/constants/design';
 import CollectionActions from '@/screens/library/CollectionActions';
 import { useLocalMix } from './hooks/useLocalMix';
 
@@ -53,11 +54,7 @@ export default function LocalMixScreen() {
           {songs.map(song => <SongRow key={song.id} song={song} />)}
         </ScrollView>
       ) : (
-        <View style={styles.empty}>
-          <Text style={[styles.emptyText, { color: colors.subtext }]}>
-            {t('library.collection.empty')}
-          </Text>
-        </View>
+        <EmptyState message={t('library.collection.empty')} />
       )}
     </SafeAreaView>
   );
@@ -67,6 +64,4 @@ const styles = StyleSheet.create({
   screen: { flex: 1 },
   list: { paddingBottom: spacing.xl },
   actions: { paddingHorizontal: spacing.page, paddingTop: spacing.sm, paddingBottom: spacing.md },
-  empty: { paddingHorizontal: spacing.page, paddingTop: spacing.xl },
-  emptyText: { ...typography.rowSubtitle },
 });

--- a/src/screens/library/LibraryCollectionScreen.tsx
+++ b/src/screens/library/LibraryCollectionScreen.tsx
@@ -1,14 +1,15 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRoute } from '@react-navigation/native'
 import { useTranslation } from 'react-i18next'
 import { notify } from '@/components/toast';
 
 import { DetailHeaderBar } from '@/components/DetailHeader'
+import EmptyState from '@/components/EmptyState'
 import { usePlayingActions } from '@/contexts/PlayingContext'
 import { useTheme } from '@/hooks/useTheme'
-import { spacing, typography } from '@/constants/design'
+import { spacing } from '@/constants/design'
 import CollectionActions from './CollectionActions'
 import LibraryList from './LibraryList'
 import LoadingLibraryList from './Loading'
@@ -121,11 +122,7 @@ const LibraryCollectionScreen: React.FC = () => {
       {isLoading && items.length === 0 ? (
         <LoadingLibraryList collection={type ?? null} />
       ) : items.length === 0 ? (
-        <View style={styles.empty}>
-          <Text style={[styles.emptyText, { color: colors.subtext }]}>
-            {t('library.collection.empty')}
-          </Text>
-        </View>
+        <EmptyState message={t('library.collection.empty')} />
       ) : (
         <LibraryList
           items={items}
@@ -145,6 +142,4 @@ export default LibraryCollectionScreen
 const styles = StyleSheet.create({
   screen: { flex: 1 },
   actions: { paddingHorizontal: spacing.page, paddingTop: spacing.sm },
-  empty: { paddingHorizontal: spacing.page, paddingTop: spacing.xl },
-  emptyText: { ...typography.rowSubtitle },
 })


### PR DESCRIPTION
## Summary
- center shared full-screen empty states within the unobscured area above the translucent dock and playing bar
- adopt the shared treatment in Library collections, Genres, and Local Mix
- retain compact empty treatments for cards, shelves, onboarding, search, and sheets
- add resolver and component coverage for dock/no-dock behavior

## Verification
- `npm run lint` (0 errors; 67 existing warnings)
- `npx tsc --noEmit`
- `npx jest --ci` (166 suites, 1,286 tests)
- visually verified Wants in the iPhone 17 Pro simulator with an active playing bar

`package.json` version is unchanged; this PR is not a release.